### PR TITLE
Quality of Life - Recipe and Tags

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisControlManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisControlManager.java
@@ -261,7 +261,6 @@ public class TardisControlManager {
             // Try the next interval in the rotation.
             location.position = getLegalPosition(location.getLevel(), location.position, originalY);
             location.position = location.position.offset(location.rotation.getNormal().multiply((int) (failOffset * (1 + ((float) i * 0.1f)))));
-            PlayerUtil.globalMessage(Component.literal(String.valueOf(i)), level.getServer());
         }
 
 

--- a/common/src/main/java/whocraft/tardis_refined/registry/BlockRegistry.java
+++ b/common/src/main/java/whocraft/tardis_refined/registry/BlockRegistry.java
@@ -61,14 +61,14 @@ public class BlockRegistry {
     // Roots
     public static final RegistrySupplier<RootPlantBlock> ROOT_PLANT_BLOCK = register("root_plant", () -> new RootPlantBlock(BlockBehaviour.Properties.of(Material.LEAVES).noOcclusion().strength(3, 3).sound(SoundType.CORAL_BLOCK)), ItemRegistry.MAIN_TAB, true);
 
-    public static final RegistrySupplier<BulkHeadDoorBlock> BULK_HEAD_DOOR = register("bulk_head_door", () -> new BulkHeadDoorBlock(BlockBehaviour.Properties.of(Material.LEAVES).noOcclusion().strength(3, 3).sound(SoundType.CORAL_BLOCK)), ItemRegistry.MAIN_TAB, true);
+    public static final RegistrySupplier<BulkHeadDoorBlock> BULK_HEAD_DOOR = register("bulk_head_door", () -> new BulkHeadDoorBlock(BlockBehaviour.Properties.of(Material.LEAVES).noOcclusion().strength(3, 3).sound(SoundType.CORAL_BLOCK)), null, true);
 
     //////////// REMOVE THESE BLOCKS FROM CREATIVE TABS BEFORE PRODUCTION
 
     // ARS Tree
     public static final RegistrySupplier<ArsEggBlock> ARS_EGG = register("ars_egg", () -> new ArsEggBlock(BlockBehaviour.Properties.of(Material.LEAVES).noOcclusion().strength(3, 3).sound(SoundType.AZALEA_LEAVES).lightLevel((x) -> {
         return 12;
-    })), ItemRegistry.MAIN_TAB, true);
+    })), null, true);
     public static final RegistrySupplier<Block> ARS_LEAVES = register("ars_leaves", () -> new LeavesBlock(BlockBehaviour.Properties.of(Material.LEAVES).noOcclusion().strength(3, 3).sound(SoundType.AZALEA_LEAVES)), null, true);
     public static final RegistrySupplier<SlabBlock> ARS_LEAVES_SLAB = register("ars_leaves_slab", () -> new SlabBlock(BlockBehaviour.Properties.of(Material.LEAVES).noOcclusion().strength(3, 3).sound(SoundType.AZALEA_LEAVES)), null, true);
     public static final RegistrySupplier<FenceBlock> ARS_LEAVES_FENCE = register("ars_leaves_fence", () -> new FenceBlock(BlockBehaviour.Properties.of(Material.LEAVES).noOcclusion().strength(3, 3).sound(SoundType.AZALEA_LEAVES)), null, true);

--- a/forge/src/main/java/whocraft/tardis_refined/common/data/ProviderBlockTags.java
+++ b/forge/src/main/java/whocraft/tardis_refined/common/data/ProviderBlockTags.java
@@ -41,5 +41,18 @@ public class ProviderBlockTags extends BlockTagsProvider {
             }
         }
 
+        tag(BlockTags.DRAGON_IMMUNE).add(BlockRegistry.GLOBAL_SHELL_BLOCK.get());
+        tag(BlockTags.DRAGON_IMMUNE).add(BlockRegistry.ROOT_SHELL_BLOCK.get());
+
+        tag(BlockTags.MINEABLE_WITH_PICKAXE).add(BlockRegistry.CONSOLE_CONFIGURATION_BLOCK.get());
+        tag(BlockTags.MINEABLE_WITH_PICKAXE).add(BlockRegistry.LANDING_PAD.get());
+        tag(BlockTags.MINEABLE_WITH_PICKAXE).add(BlockRegistry.FLIGHT_DETECTOR.get());
+        tag(BlockTags.MINEABLE_WITH_PICKAXE).add(BlockRegistry.TERRAFORMER_BLOCK.get());
+        tag(BlockTags.MINEABLE_WITH_PICKAXE).add(BlockRegistry.ROOT_PLANT_BLOCK.get());
+
+        tag(BlockTags.NEEDS_IRON_TOOL).add(BlockRegistry.CONSOLE_CONFIGURATION_BLOCK.get());
+        tag(BlockTags.NEEDS_IRON_TOOL).add(BlockRegistry.LANDING_PAD.get());
+        tag(BlockTags.NEEDS_IRON_TOOL).add(BlockRegistry.FLIGHT_DETECTOR.get());
+        tag(BlockTags.NEEDS_IRON_TOOL).add(BlockRegistry.TERRAFORMER_BLOCK.get());
     }
 }

--- a/forge/src/main/java/whocraft/tardis_refined/common/data/RecipeProvider.java
+++ b/forge/src/main/java/whocraft/tardis_refined/common/data/RecipeProvider.java
@@ -25,6 +25,7 @@ public class RecipeProvider extends net.minecraft.data.recipes.RecipeProvider {
         ShapedRecipeBuilder.shaped(ItemRegistry.PATTERN_MANIPULATOR.get()).pattern("RCL").pattern("EAE").pattern(" S ").define('S', Items.STICK).define('E', Items.REDSTONE).define('A', Items.IRON_INGOT).define('R', Items.RED_DYE).define('C', Items.GREEN_DYE).define('L', Items.LAPIS_LAZULI).unlockedBy("has_crafting_table", has(BlockRegistry.CONSOLE_CONFIGURATION_BLOCK.get())).save(consumer);
         ShapedRecipeBuilder.shaped(ItemRegistry.DRILL.get()).pattern(" P ").pattern("PCP").pattern("IRI").define('P', Items.IRON_PICKAXE).define('R', Items.REDSTONE).define('I', Items.IRON_INGOT).define('C', Items.COBBLESTONE).unlockedBy("has_crafting_table", has(Items.REDSTONE)).save(consumer);
         ShapedRecipeBuilder.shaped(BlockRegistry.FLIGHT_DETECTOR.get()).pattern("G G").pattern("IDI").pattern("III").define('G', Items.GOLD_INGOT).define('I', Items.IRON_INGOT).define('D', Blocks.DAYLIGHT_DETECTOR).unlockedBy("has_dalight_detector", has(Blocks.DAYLIGHT_DETECTOR)).save(consumer);
+        ShapelessRecipeBuilder.shapeless(BlockRegistry.GLOBAL_DOOR_BLOCK.get()).requires(Items.IRON_INGOT).requires(Items.TRIPWIRE_HOOK).requires(Items.IRON_DOOR).unlockedBy("has_crafting_table", has(Blocks.IRON_DOOR)).save(consumer);
 
         ShapelessRecipeBuilder.shapeless(ItemRegistry.KEY.get()).requires(Items.IRON_INGOT).requires(Items.TRIPWIRE_HOOK).unlockedBy("has_crafting_table", has(Blocks.TRIPWIRE_HOOK)).save(consumer);
     }


### PR DESCRIPTION
This PR fixes a few of the quality of life issues we were having.

- Tools are now required to break any device blocks
- The Ender Dragon can no longer destroy the TARDIS
- Added a crafting recipe for the internal doors

Additionally
- Removed direction message in chat that should not have been merged
- Removed the Bulk Head Door and ARS egg from the creative menu