### PR TITLE
Fix landing on ice, check isLiquid instead of the block

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisControlManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisControlManager.java
@@ -326,7 +326,7 @@ public class TardisControlManager {
     }
 
     private boolean isSolidBlock(ServerLevel level, BlockPos pos) {
-        return level.getBlockState(pos).getMaterial().isSolidBlocking() || level.getBlockState(pos).getBlock() == Blocks.WATER || level.getBlockState(pos).getBlock() == Blocks.LAVA;
+        return level.getBlockState(pos).getMaterial().isSolid() || level.getBlockState(pos).getMaterial().isLiquid();
     }
 
     public boolean beginFlight(boolean autoLand) {


### PR DESCRIPTION
Instead of checking if the block is solid blocking, which ice is not for some reason, check if block quite literally is solid. Instead of checking if the block is water or lava, just check if it is just liquid.

Fixes half of #135 