### PR TITLE
Remove Shalka Desktop

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/TardisDesktops.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/TardisDesktops.java
@@ -65,7 +65,6 @@ public class TardisDesktops {
         addDefaultDesktop(new DesktopTheme("nuka", "desktop/nuka"));
         addDefaultDesktop(new DesktopTheme("future_nostalgia", "desktop/future_nostalgia"));
         addDefaultDesktop(new DesktopTheme("violet_eye", "desktop/violet_eye"));
-        addDefaultDesktop(new DesktopTheme("shalka", "desktop/shalka"));
         addDefaultDesktop(new DesktopTheme("arnet", "desktop/arnet"));
         return DEFAULT_DESKTOPS;
     }

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisExteriorManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisExteriorManager.java
@@ -176,7 +176,7 @@ public class TardisExteriorManager extends BaseHandler {
         ResourceLocation theme = (aestheticHandler.getShellTheme() != null) ? aestheticHandler.getShellTheme() : ShellTheme.HALF_BAKED.getId();
         ShellTheme shellTheme = ShellTheme.getShellTheme(theme);
 
-        BlockState targetBlockState = BlockRegistry.GLOBAL_SHELL_BLOCK.get().defaultBlockState()
+        BlockState targetBlockState = TRBlockRegistry.GLOBAL_SHELL_BLOCK.get().defaultBlockState()
                 .setValue(GlobalShellBlock.FACING, location.getDirection().getOpposite())
                 .setValue(GlobalShellBlock.REGEN, false)
                 .setValue(LOCKED, operator.getExteriorManager().locked)


### PR DESCRIPTION
Removes the Shalka desktop as it is not currently up to scratch with our standards.

To be readded later. 