### PR TITLE
Removed LastKnownLocation for CurrentLocation

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/GlobalShellBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/GlobalShellBlockEntity.java
@@ -117,7 +117,7 @@ public class GlobalShellBlockEntity extends ShellBaseBlockEntity {
                     ResourceKey<Level> dimension = this.getTardisId();
 
                     if (stack.is(Items.SHEARS) && cap.getAestheticHandler().getShellTheme() == ShellTheme.HALF_BAKED.getId() && !cap.getPilotingManager().isInFlight()) {
-                        cap.getAestheticHandler().setShellTheme(ShellTheme.FACTORY.getId(), cap.getExteriorManager().getLastKnownLocation());
+                        cap.getAestheticHandler().setShellTheme(ShellTheme.FACTORY.getId(), cap.getPilotingManager().getCurrentLocation());
                         level.playSound(null, blockPos, SoundEvents.SHEEP_SHEAR, SoundSource.BLOCKS, 1, 1);
 
                         spawnCoralItems();

--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
@@ -27,6 +27,7 @@ import whocraft.tardis_refined.common.capability.upgrades.Upgrades;
 import whocraft.tardis_refined.common.dimension.DimensionHandler;
 import whocraft.tardis_refined.common.tardis.ExteriorShell;
 import whocraft.tardis_refined.common.tardis.TardisDesktops;
+import whocraft.tardis_refined.common.tardis.TardisNavLocation;
 import whocraft.tardis_refined.common.tardis.themes.DesktopTheme;
 import whocraft.tardis_refined.common.util.Platform;
 import whocraft.tardis_refined.common.util.PlayerUtil;
@@ -114,7 +115,7 @@ public abstract class ShellBaseBlockEntity extends BlockEntity implements Exteri
                             }
                         }
                     }
-                    cap.enterTardis(entity, externalShellPos, serverLevel, blockState.getValue(ShellBaseBlock.FACING));
+                    cap.enterTardis(entity, getBlockPos(), serverLevel, blockState.getValue(ShellBaseBlock.FACING));
                 } else {
                     if (!cap.isTardisReady()) {
                         if (entity instanceof Player player)
@@ -141,20 +142,28 @@ public abstract class ShellBaseBlockEntity extends BlockEntity implements Exteri
 
     @Override
     public void tick(Level level, BlockPos blockPos, BlockState blockState, ShellBaseBlockEntity blockEntity) {
-//        if(level.getGameTime() % DUPLICATION_CHECK_TIME == 0 && !level.isClientSide){
-//            ResourceKey<Level> tardisId = getTardisId();
-//            if(tardisId == null) return;
-//            ServerLevel tardisLevel = Platform.getServer().getLevel(tardisId);
-//            BlockPos myCurrentPosition = getBlockPos();
-//
-//            TardisLevelOperator.get(tardisLevel).ifPresent(tardisLevelOperator -> {
-//                BlockPos blockPosLastKnown = tardisLevelOperator.getExteriorManager().getLastKnownLocation().getPosition();
-//                BlockPos wantedDestination = tardisLevelOperator.getPilotingManager().getTargetLocation().getPosition();
-//
-//                if(myCurrentPosition != blockPosLastKnown && myCurrentPosition != wantedDestination && myCurrentPosition != BlockPos.ZERO){
-//                    level.removeBlock(worldPosition, false);
-//                }
-//            });
-//        }
+        if(level.getGameTime() % DUPLICATION_CHECK_TIME == 0 && !level.isClientSide){
+            ResourceKey<Level> tardisId = getTardisId();
+            if(tardisId == null) return;
+            ServerLevel tardisLevel = Platform.getServer().getLevel(tardisId);
+            BlockPos myCurrentPosition = getBlockPos();
+
+            TardisLevelOperator.get(tardisLevel).ifPresent(tardisLevelOperator -> {
+                BlockPos currentLocation = tardisLevelOperator.getPilotingManager().getCurrentLocation().getPosition();
+                BlockPos wantedDestination = tardisLevelOperator.getPilotingManager().getTargetLocation().getPosition();
+
+
+                if (currentLocation == null) {
+                    Direction direction = blockState.getValue(ShellBaseBlock.FACING);
+                    ServerLevel serverLevel = Platform.getServer().getLevel(level.dimension());
+                    tardisLevelOperator.getPilotingManager().setCurrentLocation(new TardisNavLocation(getBlockPos(), direction != null ? direction : Direction.NORTH, serverLevel));
+                }
+
+                if (!myCurrentPosition.equals(currentLocation) && !myCurrentPosition.equals(wantedDestination) ) {
+                    level.removeBlock(myCurrentPosition, false);
+                }
+
+            });
+        }
     }
 }

--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
@@ -28,6 +28,7 @@ import whocraft.tardis_refined.common.dimension.DimensionHandler;
 import whocraft.tardis_refined.common.tardis.ExteriorShell;
 import whocraft.tardis_refined.common.tardis.TardisDesktops;
 import whocraft.tardis_refined.common.tardis.TardisNavLocation;
+import whocraft.tardis_refined.common.tardis.manager.TardisPilotingManager;
 import whocraft.tardis_refined.common.tardis.themes.DesktopTheme;
 import whocraft.tardis_refined.common.util.Platform;
 import whocraft.tardis_refined.common.util.PlayerUtil;
@@ -149,14 +150,17 @@ public abstract class ShellBaseBlockEntity extends BlockEntity implements Exteri
             BlockPos myCurrentPosition = getBlockPos();
 
             TardisLevelOperator.get(tardisLevel).ifPresent(tardisLevelOperator -> {
-                BlockPos currentLocation = tardisLevelOperator.getPilotingManager().getCurrentLocation().getPosition();
-                BlockPos wantedDestination = tardisLevelOperator.getPilotingManager().getTargetLocation().getPosition();
+
+                TardisPilotingManager pilotingManager = tardisLevelOperator.getPilotingManager();
+
+                BlockPos currentLocation = pilotingManager.getCurrentLocation().getPosition();
+                BlockPos wantedDestination = pilotingManager.getTargetLocation().getPosition();
 
 
                 if (currentLocation == null) {
                     Direction direction = blockState.getValue(ShellBaseBlock.FACING);
                     ServerLevel serverLevel = Platform.getServer().getLevel(level.dimension());
-                    tardisLevelOperator.getPilotingManager().setCurrentLocation(new TardisNavLocation(getBlockPos(), direction != null ? direction : Direction.NORTH, serverLevel));
+                    pilotingManager.setCurrentLocation(new TardisNavLocation(getBlockPos(), direction != null ? direction : Direction.NORTH, serverLevel));
                 }
 
                 if (!myCurrentPosition.equals(currentLocation) && !myCurrentPosition.equals(wantedDestination) ) {

--- a/common/src/main/java/whocraft/tardis_refined/common/capability/TardisLevelOperator.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/capability/TardisLevelOperator.java
@@ -145,9 +145,11 @@ public class TardisLevelOperator {
     }
 
     public void tick(ServerLevel level) {
-        interiorManager.tick(level);
-        pilotingManager.tick(level);
-        flightDanceManager.tick();
+
+        if (interiorManager != null) {  interiorManager.tick(level);}
+        if (pilotingManager != null) {  pilotingManager.tick(level);}
+        if (flightDanceManager != null) {  flightDanceManager.tick();}
+
         
         var shouldSync = level.getGameTime() % 40 == 0;
         if (shouldSync) {
@@ -209,6 +211,10 @@ public class TardisLevelOperator {
             return false;
         }
 
+        if (aestheticHandler == null || pilotingManager == null) {
+            return false;
+        }
+
         if (aestheticHandler.getShellTheme() != null) {
             ResourceLocation theme = aestheticHandler.getShellTheme();
             if (ModCompatChecker.immersivePortals() && !(this.internalDoor instanceof RootShellDoorBlockEntity)) {
@@ -251,8 +257,6 @@ public class TardisLevelOperator {
         } else {
             TardisEvents.DOOR_OPENED_EVENT.invoker().onDoorOpen(this);
         }
-
-
 
         if (this.pilotingManager != null) {
             if (this.pilotingManager.getCurrentLocation() != null) {

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/RandomControl.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/RandomControl.java
@@ -35,7 +35,7 @@ public class RandomControl extends Control {
             );
 
             if (pilotManager.isInFlight()) {
-                operator.getPilotingManager().recalculateFlightDistance();
+                pilotManager.recalculateFlightDistance();
             }
 
             PlayerUtil.sendMessage(player, Component.translatable(pilotManager.getTargetLocation().getPosition().toShortString()), true);

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/RandomControl.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/RandomControl.java
@@ -26,7 +26,7 @@ public class RandomControl extends Control {
             TardisPilotingManager pilotManager = operator.getPilotingManager();
 
             int increment = pilotManager.getCordIncrement();
-            BlockPos currentExLoc = operator.getExteriorManager().getLastKnownLocation().getPosition();
+            BlockPos currentExLoc = operator.getPilotingManager().getCurrentLocation().getPosition();
             pilotManager.getTargetLocation().setPosition(
                     new BlockPos((currentExLoc.getX() - (increment / 2)) +  operator.getLevel().random.nextInt(increment * 2),
                             150,

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/ReadoutControl.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/ReadoutControl.java
@@ -23,8 +23,8 @@ public class ReadoutControl extends Control {
     @Override
     public boolean onLeftClick(TardisLevelOperator operator, ConsoleTheme theme, ControlEntity controlEntity, Player player) {
 
-        TardisNavLocation currentPosition = operator.getExteriorManager().getLastKnownLocation();
-        PlayerUtil.sendMessage(player, Component.translatable("Current - X: " + currentPosition.getPosition().getX() + " Y: " + currentPosition.getPosition().getY()+ " Z: " + currentPosition.getPosition().getZ() +  "F: " + currentPosition.getDirection().getName() + " D: " + currentPosition.getDimensionKey().location().getPath()), true);
+        TardisNavLocation currentPosition = operator.getPilotingManager().getCurrentLocation();
+        PlayerUtil.sendMessage(player, Component.translatable("Current - X: " + currentPosition.getPosition().getX() + " Y: " + currentPosition.getPosition().getY()+ " Z: " + currentPosition.getPosition().getZ() +  " F: " + currentPosition.getDirection().getName() + " D: " + currentPosition.getDimensionKey().location().getPath()), true);
 
 
         return true;

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/ReadoutControl.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/ReadoutControl.java
@@ -11,6 +11,7 @@ import whocraft.tardis_refined.common.tardis.control.Control;
 import whocraft.tardis_refined.common.tardis.control.ControlSpecification;
 import whocraft.tardis_refined.common.tardis.themes.ConsoleTheme;
 import whocraft.tardis_refined.common.util.PlayerUtil;
+import whocraft.tardis_refined.constants.ModMessages;
 
 public class ReadoutControl extends Control {
     public ReadoutControl(ResourceLocation id) {
@@ -24,7 +25,7 @@ public class ReadoutControl extends Control {
     public boolean onLeftClick(TardisLevelOperator operator, ConsoleTheme theme, ControlEntity controlEntity, Player player) {
 
         TardisNavLocation currentPosition = operator.getPilotingManager().getCurrentLocation();
-        PlayerUtil.sendMessage(player, Component.translatable("Current - X: " + currentPosition.getPosition().getX() + " Y: " + currentPosition.getPosition().getY()+ " Z: " + currentPosition.getPosition().getZ() +  " F: " + currentPosition.getDirection().getName() + " D: " + currentPosition.getDimensionKey().location().getPath()), true);
+        PlayerUtil.sendMessage(player, Component.translatable(ModMessages.CURRENT).append(  " - X: " + currentPosition.getPosition().getX() + " Y: " + currentPosition.getPosition().getY()+ " Z: " + currentPosition.getPosition().getZ() +  " F: " + currentPosition.getDirection().getName() + " D: " + currentPosition.getDimensionKey().location().getPath()), true);
 
 
         return true;
@@ -34,7 +35,7 @@ public class ReadoutControl extends Control {
     public boolean onRightClick(TardisLevelOperator operator, ConsoleTheme theme, ControlEntity controlEntity, Player player) {
 
         TardisNavLocation targetLocation = operator.getPilotingManager().getTargetLocation();
-        PlayerUtil.sendMessage(player, Component.translatable("Destination - X: " + targetLocation.getPosition().getX() + " Y: " + targetLocation.getPosition().getY()+ " Z: " + targetLocation.getPosition().getZ() +  " F: " + targetLocation.getDirection().getName() + " D: " + targetLocation.getDimensionKey().location().getPath()), true);
+        PlayerUtil.sendMessage(player, Component.translatable(ModMessages.DESTINATION).append(" - X: " + targetLocation.getPosition().getX() + " Y: " + targetLocation.getPosition().getY()+ " Z: " + targetLocation.getPosition().getZ() +  " F: " + targetLocation.getDirection().getName() + " D: " + targetLocation.getDimensionKey().location().getPath()), true);
 
         return true;
     }

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/control/ship/MonitorControl.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/control/ship/MonitorControl.java
@@ -40,7 +40,7 @@ public class MonitorControl extends Control {
                     isSyncingKey = true;
             }
             if (!isSyncingKey)
-                new OpenMonitorMessage(operator.getInteriorManager().isWaitingToGenerate(), operator.getExteriorManager().getLastKnownLocation(), operator.getPilotingManager().getTargetLocation(), operator.getUpgradeHandler()).send((ServerPlayer) player);
+                new OpenMonitorMessage(operator.getInteriorManager().isWaitingToGenerate(), operator.getPilotingManager().getCurrentLocation(), operator.getPilotingManager().getTargetLocation(), operator.getUpgradeHandler()).send((ServerPlayer) player);
             return true;
         }
         return false;

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisExteriorManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisExteriorManager.java
@@ -39,12 +39,18 @@ public class TardisExteriorManager extends BaseHandler {
     }
 
     public void setLocked(boolean locked) {
-        if (operator.getPilotingManager().isInFlight()) {
-            return;
-        }
+
+        TardisPilotingManager pilotingManager = this.operator.getPilotingManager();
+
+
         this.locked = locked;
-        if (this.operator.getPilotingManager() != null) {
-            TardisNavLocation currentLocation = this.operator.getPilotingManager().getCurrentLocation();
+        if (pilotingManager != null) {
+
+            if (pilotingManager.isInFlight()) {
+                return;
+            }
+
+            TardisNavLocation currentLocation = pilotingManager.getCurrentLocation();
             Level level = currentLocation.getLevel();
             BlockPos extPos = currentLocation.getPosition();
             if (level.getBlockState(extPos) != null) {
@@ -96,10 +102,19 @@ public class TardisExteriorManager extends BaseHandler {
     }
 
     public void playSoundAtShell(SoundEvent event, SoundSource source, float volume, float pitch) {
-        if (this.operator.getPilotingManager().getCurrentLocation() != null) {
-            ServerLevel lastKnownLocationLevel = this.operator.getPilotingManager().getCurrentLocation().getLevel();
-            lastKnownLocationLevel.playSound(null, this.operator.getPilotingManager().getCurrentLocation().getPosition(), event, source, volume, pitch);
+
+        TardisPilotingManager pilotingManager = this.operator.getPilotingManager();
+
+        if (pilotingManager != null) {
+            if (pilotingManager.getCurrentLocation() != null) {
+                TardisNavLocation currentLocation = pilotingManager.getCurrentLocation();
+                ServerLevel lastKnownLocationLevel = currentLocation.getLevel();
+
+                lastKnownLocationLevel.playSound(null, currentLocation.getPosition(), event, source, volume, pitch);
+            }
         }
+
+
     }
 
     public void setDoorClosed(boolean closed) {
@@ -123,6 +138,12 @@ public class TardisExteriorManager extends BaseHandler {
 
 
     public void triggerShellRegenState() {
+
+        TardisPilotingManager pilotingManager = this.operator.getPilotingManager();
+        if (pilotingManager == null) {
+            return;
+        }
+
         TardisNavLocation currentPosition = this.operator.getPilotingManager().getCurrentLocation();
         if(currentPosition == null) return;
         BlockPos lastKnownLocationPosition = currentPosition.getPosition();
@@ -136,6 +157,11 @@ public class TardisExteriorManager extends BaseHandler {
 
     public void removeExteriorBlock() {
         this.isLanding = false;
+
+        TardisPilotingManager pilotingManager = this.operator.getPilotingManager();
+        if (pilotingManager == null) {
+            return;
+        }
 
         TardisNavLocation currentPosition = this.operator.getPilotingManager().getCurrentLocation();
         if (currentPosition != null) {
@@ -192,6 +218,11 @@ public class TardisExteriorManager extends BaseHandler {
 
 
     public boolean isExitLocationSafe() {
+
+        TardisPilotingManager pilotingManager = this.operator.getPilotingManager();
+        if (pilotingManager == null) {
+            return false;
+        }
 
         TardisNavLocation currentPosition = this.operator.getPilotingManager().getCurrentLocation();
         if(currentPosition == null) return false;

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisExteriorManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisExteriorManager.java
@@ -10,6 +10,7 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluids;
 import whocraft.tardis_refined.common.block.shell.GlobalShellBlock;
@@ -32,7 +33,6 @@ public class TardisExteriorManager extends BaseHandler {
     private double fuelForShellChange = 15; // Amount of fuel required to change the shell
 
     private final TardisLevelOperator operator;
-    private TardisNavLocation lastKnownLocation = TardisNavLocation.ORIGIN;
 
     public boolean locked() {
         return locked;
@@ -43,10 +43,10 @@ public class TardisExteriorManager extends BaseHandler {
             return;
         }
         this.locked = locked;
-        if (this.getLastKnownLocation() != null) {
-            TardisNavLocation lastKnownLocation = this.getLastKnownLocation();
-            Level level = lastKnownLocation.getLevel();
-            BlockPos extPos = lastKnownLocation.getPosition();
+        if (this.operator.getPilotingManager() != null) {
+            TardisNavLocation currentLocation = this.operator.getPilotingManager().getCurrentLocation();
+            Level level = currentLocation.getLevel();
+            BlockPos extPos = currentLocation.getPosition();
             if (level.getBlockState(extPos) != null) {
                 BlockState extState = level.getBlockState(extPos);
                 if (extState.getBlock() instanceof GlobalShellBlock shellBlock) {
@@ -79,25 +79,6 @@ public class TardisExteriorManager extends BaseHandler {
         this.operator = operator;
     }
 
-    public void setLastKnownLocation(TardisNavLocation lastKnownLocation) {
-        this.lastKnownLocation = lastKnownLocation;
-    }
-
-    public TardisNavLocation getLastKnownLocation() {
-
-        if(lastKnownLocation == null){
-            return TardisNavLocation.ORIGIN;
-        }
-
-        return this.lastKnownLocation;
-    }
-
-
-    public ServerLevel getLevel() {
-        return this.getLastKnownLocation().getLevel();
-    }
-
-
     @Override
     public void tick() {
 
@@ -105,23 +86,19 @@ public class TardisExteriorManager extends BaseHandler {
     @Override
     public CompoundTag saveData(CompoundTag tag) {
 
-        if (this.lastKnownLocation != null) {
-            NbtConstants.putTardisNavLocation(tag, "lk_ext", this.lastKnownLocation);
-        }
         tag.putBoolean(NbtConstants.LOCKED, locked);
 
         return tag;
     }
     @Override
     public void loadData(CompoundTag tag) {
-        this.lastKnownLocation = NbtConstants.getTardisNavLocation(tag, "lk_ext", operator);
         locked = tag.getBoolean(NbtConstants.LOCKED);
     }
 
     public void playSoundAtShell(SoundEvent event, SoundSource source, float volume, float pitch) {
-        if (lastKnownLocation != null) {
-            ServerLevel lastKnownLocationLevel = lastKnownLocation.getLevel();
-            lastKnownLocationLevel.playSound(null, lastKnownLocation.getPosition(), event, source, volume, pitch);
+        if (this.operator.getPilotingManager().getCurrentLocation() != null) {
+            ServerLevel lastKnownLocationLevel = this.operator.getPilotingManager().getCurrentLocation().getLevel();
+            lastKnownLocationLevel.playSound(null, this.operator.getPilotingManager().getCurrentLocation().getPosition(), event, source, volume, pitch);
         }
     }
 
@@ -131,22 +108,25 @@ public class TardisExteriorManager extends BaseHandler {
             closed = true;
         }
 
-        if(lastKnownLocation == null) return;
-        ServerLevel lastKnownLocationLevel = lastKnownLocation.getLevel();
+        TardisNavLocation currentPosition = this.operator.getPilotingManager().getCurrentLocation();
+
+        if(currentPosition == null) return;
+        ServerLevel lastKnownLocationLevel = currentPosition.getLevel();
 
         // Get the exterior block.
-        BlockState state = lastKnownLocationLevel.getBlockState(lastKnownLocation.getPosition());
+        BlockState state = lastKnownLocationLevel.getBlockState(currentPosition.getPosition());
         if (state.hasProperty(ShellBaseBlock.OPEN)) {
-            lastKnownLocationLevel.setBlock(lastKnownLocation.getPosition(), state.setValue(ShellBaseBlock.OPEN, !closed), 2);
+            lastKnownLocationLevel.setBlock(currentPosition.getPosition(), state.setValue(ShellBaseBlock.OPEN, !closed), 2);
             playSoundAtShell(locked ? SoundEvents.IRON_DOOR_CLOSE : SoundEvents.IRON_DOOR_OPEN, SoundSource.BLOCKS, 1, locked ? 1.4F : 1F);
         }
     }
 
 
     public void triggerShellRegenState() {
-        if(lastKnownLocation == null) return;
-        BlockPos lastKnownLocationPosition = lastKnownLocation.getPosition();
-        ServerLevel lastKnownLocationLevel = lastKnownLocation.getLevel();
+        TardisNavLocation currentPosition = this.operator.getPilotingManager().getCurrentLocation();
+        if(currentPosition == null) return;
+        BlockPos lastKnownLocationPosition = currentPosition.getPosition();
+        ServerLevel lastKnownLocationLevel = currentPosition.getLevel();
 
         BlockState state = lastKnownLocationLevel.getBlockState(lastKnownLocationPosition);
         if (lastKnownLocationLevel == null) return;
@@ -156,9 +136,11 @@ public class TardisExteriorManager extends BaseHandler {
 
     public void removeExteriorBlock() {
         this.isLanding = false;
-        if (lastKnownLocation != null) {
-            BlockPos lastKnownLocationPosition = lastKnownLocation.getPosition();
-            ServerLevel lastKnownLocationLevel = lastKnownLocation.getLevel();
+
+        TardisNavLocation currentPosition = this.operator.getPilotingManager().getCurrentLocation();
+        if (currentPosition != null) {
+            BlockPos lastKnownLocationPosition = currentPosition.getPosition();
+            ServerLevel lastKnownLocationLevel = currentPosition.getLevel();
             ChunkPos chunkPos = lastKnownLocationLevel.getChunk(lastKnownLocationPosition).getPos();
             //Force load chunk
             lastKnownLocationLevel.setChunkForced(chunkPos.x, chunkPos.z, true); //Set chunk to be force loaded to properly remove block
@@ -175,6 +157,9 @@ public class TardisExteriorManager extends BaseHandler {
         AestheticHandler aestheticHandler = operator.getAestheticHandler();
         ResourceLocation theme = (aestheticHandler.getShellTheme() != null) ? aestheticHandler.getShellTheme() : ShellTheme.HALF_BAKED.getId();
         ShellTheme shellTheme = ShellTheme.getShellTheme(theme);
+
+        //remove the exterior block
+        location.getLevel().setBlock(location.getPosition(), Blocks.AIR.defaultBlockState(), Block.UPDATE_ALL);
 
         BlockState targetBlockState = TRBlockRegistry.GLOBAL_SHELL_BLOCK.get().defaultBlockState()
                 .setValue(GlobalShellBlock.FACING, location.getDirection().getOpposite())
@@ -202,14 +187,17 @@ public class TardisExteriorManager extends BaseHandler {
         //Un-force load target chunk
         targetLevel.setChunkForced(chunkPos.x, chunkPos.z, false); //Set chunk to be not be force loaded after we place the block
 
-        setLastKnownLocation(location);
         this.isLanding = true;
     }
 
 
     public boolean isExitLocationSafe() {
-        BlockPos lastKnownLocationPosition = lastKnownLocation.getPosition();
-        ServerLevel lastKnownLocationLevel = lastKnownLocation.getLevel();
+
+        TardisNavLocation currentPosition = this.operator.getPilotingManager().getCurrentLocation();
+        if(currentPosition == null) return false;
+
+        BlockPos lastKnownLocationPosition = currentPosition.getPosition();
+        ServerLevel lastKnownLocationLevel = currentPosition.getLevel();
         if (lastKnownLocationLevel.getBlockEntity(lastKnownLocationPosition) instanceof ExteriorShell shellBaseBlockEntity) {
             BlockPos landingArea = shellBaseBlockEntity.getExitPosition();
             if (lastKnownLocationLevel.getBlockState(landingArea).isAir()) {

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisInteriorManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisInteriorManager.java
@@ -172,6 +172,15 @@ public class TardisInteriorManager extends BaseHandler {
 
         }
 
+        TardisExteriorManager exteriorManager = this.operator.getExteriorManager();
+        if (exteriorManager == null) {
+            return;
+        }
+        TardisPilotingManager pilotingManager = this.operator.getPilotingManager();
+        if (pilotingManager == null) {
+            return;
+        }
+
         if (this.isWaitingToGenerate) {
             if (level.random.nextInt(30) == 0) {
                 level.playSound(null, TardisArchitectureHandler.DESKTOP_CENTER_POS, SoundEvents.FIRE_AMBIENT, SoundSource.BLOCKS, 5.0F + level.random.nextFloat(), level.random.nextFloat() * 0.7F + 0.3F);
@@ -182,7 +191,7 @@ public class TardisInteriorManager extends BaseHandler {
             }
 
             if (level.players().isEmpty()) {
-                this.operator.getExteriorManager().triggerShellRegenState();
+                exteriorManager.triggerShellRegenState();
                 operator.setDoorClosed(true);
                 generateDesktop(this.preparedTheme);
 
@@ -199,15 +208,14 @@ public class TardisInteriorManager extends BaseHandler {
 
             if (interiorGenerationCooldown == 0) {
                 this.operator.setShellTheme((this.operator.getAestheticHandler().getShellTheme() != null) ? operator.getAestheticHandler().getShellTheme() : ShellTheme.HALF_BAKED.getId(), true);
-                this.operator.getExteriorManager().placeExteriorBlock(operator, this.operator.getPilotingManager().getCurrentLocation());
+                exteriorManager.placeExteriorBlock(operator, this.operator.getPilotingManager().getCurrentLocation());
                 this.isGeneratingDesktop = false;
             }
 
             if (level.getGameTime() % 60 == 0) {
-                operator.getExteriorManager().playSoundAtShell(SoundEvents.BEACON_POWER_SELECT, SoundSource.BLOCKS, 1.0F + operator.getLevel().getRandom().nextFloat(), 0.1f);
+                exteriorManager.playSoundAtShell(SoundEvents.BEACON_POWER_SELECT, SoundSource.BLOCKS, 1.0F + operator.getLevel().getRandom().nextFloat(), 0.1f);
             }
         }
-
 
         /// Airlock Logic
 

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisInteriorManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisInteriorManager.java
@@ -199,12 +199,12 @@ public class TardisInteriorManager extends BaseHandler {
 
             if (interiorGenerationCooldown == 0) {
                 this.operator.setShellTheme((this.operator.getAestheticHandler().getShellTheme() != null) ? operator.getAestheticHandler().getShellTheme() : ShellTheme.HALF_BAKED.getId(), true);
-                this.operator.getExteriorManager().placeExteriorBlock(operator, operator.getExteriorManager().getLastKnownLocation());
+                this.operator.getExteriorManager().placeExteriorBlock(operator, this.operator.getPilotingManager().getCurrentLocation());
                 this.isGeneratingDesktop = false;
             }
 
             if (level.getGameTime() % 60 == 0) {
-                operator.getExteriorManager().playSoundAtShell(SoundEvents.BEACON_POWER_SELECT, SoundSource.BLOCKS, 1.0F + operator.getExteriorManager().getLastKnownLocation().getLevel().getRandom().nextFloat(), 0.1f);
+                operator.getExteriorManager().playSoundAtShell(SoundEvents.BEACON_POWER_SELECT, SoundSource.BLOCKS, 1.0F + operator.getLevel().getRandom().nextFloat(), 0.1f);
             }
         }
 

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -164,7 +164,10 @@ public class TardisPilotingManager extends BaseHandler {
             NbtConstants.putTardisNavLocation(tag, "ctrl_fr_loc", this.fastReturnLocation);
         }
 
-        NbtConstants.putTardisNavLocation(tag, "current_location", this.currentLocation);
+        if (this.currentLocation != null) {
+            NbtConstants.putTardisNavLocation(tag, "current_location", this.currentLocation);
+        }
+
 
         tag.putInt(NbtConstants.CONTROL_INCREMENT_INDEX, this.cordIncrementIndex);
 
@@ -745,6 +748,10 @@ public class TardisPilotingManager extends BaseHandler {
         this.currentLocation = currentLocation;
     }
     public TardisNavLocation getCurrentLocation() {
+        if (this.currentLocation == null) {
+            return TardisNavLocation.ORIGIN;
+        }
+
         return this.currentLocation;
     }
 

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -54,6 +54,7 @@ public class TardisPilotingManager extends BaseHandler {
 
     // Location based.
     private TardisNavLocation targetLocation;
+    private TardisNavLocation currentLocation;
     private TardisNavLocation fastReturnLocation;
 
     // Inflight timers (ticks)
@@ -105,6 +106,7 @@ public class TardisPilotingManager extends BaseHandler {
 
         this.isPassivelyRefuelling = tag.getBoolean(NbtConstants.IS_PASSIVELY_REFUELING);
 
+        this.currentLocation = NbtConstants.getTardisNavLocation(tag, "current_location", operator);
         this.targetLocation = NbtConstants.getTardisNavLocation(tag, "ctrl_target", operator);
         this.fastReturnLocation = NbtConstants.getTardisNavLocation(tag, "ctrl_fr_loc", operator);
 
@@ -162,6 +164,8 @@ public class TardisPilotingManager extends BaseHandler {
             NbtConstants.putTardisNavLocation(tag, "ctrl_fr_loc", this.fastReturnLocation);
         }
 
+        NbtConstants.putTardisNavLocation(tag, "current_location", this.currentLocation);
+
         tag.putInt(NbtConstants.CONTROL_INCREMENT_INDEX, this.cordIncrementIndex);
 
         tag.putDouble(NbtConstants.FUEL, this.fuel);
@@ -172,10 +176,8 @@ public class TardisPilotingManager extends BaseHandler {
 
     public void tick(Level level) {
 
-
         if (targetLocation == null) {
-
-            var location = this.operator.getExteriorManager().getLastKnownLocation();
+            var location = currentLocation;
             if (targetLocation != null) {
                 this.targetLocation = location;
             } else {
@@ -213,6 +215,7 @@ public class TardisPilotingManager extends BaseHandler {
 
     private void onFlightTick(Level level) {
         // Don't continue the flight if the throttle isn't active!!!
+
         if (this.throttleStage != 0 || this.autoLand) {
             ticksInFlight++;
 
@@ -317,7 +320,6 @@ public class TardisPilotingManager extends BaseHandler {
             return true;
         }
     }
-
 
     public TardisNavLocation findClosestValidPosition(TardisNavLocation location) {
         ServerLevel level = location.getLevel();
@@ -467,14 +469,16 @@ public class TardisPilotingManager extends BaseHandler {
             this.isPassivelyRefuelling = false;
             this.flightDistance = 0;
             this.distanceCovered = 0;
-            this.fastReturnLocation = this.operator.getExteriorManager().getLastKnownLocation();
+
+
+
+            this.fastReturnLocation = new TardisNavLocation(this.currentLocation.getPosition(), this.currentLocation.getDirection(), this.currentLocation.getLevel());
+
 
             TardisNavLocation targetPosition = this.operator.getPilotingManager().getTargetLocation();
-            TardisNavLocation lastKnownLocation = this.operator.getExteriorManager().getLastKnownLocation();
+            TardisNavLocation lastKnownLocation = new TardisNavLocation(this.currentLocation.getPosition(), this.currentLocation.getDirection(), this.currentLocation.getLevel());
 
             // Do we not have a last known location?
-
-            System.out.println(lastKnownLocation.getPosition().toShortString());
 
             this.flightDistance = calculateFlightDistance(lastKnownLocation, targetPosition);
 
@@ -520,7 +524,7 @@ public class TardisPilotingManager extends BaseHandler {
 
     public void recalculateFlightDistance() {
         TardisNavLocation targetPosition = this.operator.getPilotingManager().getTargetLocation();
-        TardisNavLocation lastKnownLocation = this.operator.getExteriorManager().getLastKnownLocation();
+        TardisNavLocation lastKnownLocation = new TardisNavLocation(this.currentLocation.getPosition(), this.currentLocation.getDirection(), this.currentLocation.getLevel());
 
         this.flightDistance = calculateFlightDistance(lastKnownLocation, targetPosition);
         this.operator.getFlightDanceManager().startFlightDance(this.currentConsole);
@@ -563,6 +567,8 @@ public class TardisPilotingManager extends BaseHandler {
             TardisNavLocation landingLocation = this.targetLocation;
             TardisNavLocation location = findClosestValidPosition(landingLocation);
 
+            currentLocation = location;
+
             exteriorManager.placeExteriorBlock(operator, location);
 
             exteriorManager.playSoundAtShell(TRSoundRegistry.TARDIS_LAND.get(), SoundSource.BLOCKS, 1, 1);
@@ -581,8 +587,6 @@ public class TardisPilotingManager extends BaseHandler {
                 PlayerUtil.sendMessage(player, Component.translatable("+" + totalPoints + " XP"), true);
             }
 
-
-
             return true;
         }
         return false;
@@ -595,14 +599,15 @@ public class TardisPilotingManager extends BaseHandler {
      * @param dramatic Play sounds to show the TARDIS doesn't like it.
      */
     private void endFlightEarly(boolean dramatic) {
+
         BlockPos targetPosition = this.targetLocation.getPosition();
-        BlockPos startingPosition = this.operator.getExteriorManager().getLastKnownLocation().getPosition();
+        BlockPos startingPosition = this.currentLocation.getPosition();
         float percentage = this.getFlightPercentageCovered();
         float percentageX = (targetPosition.getX() - startingPosition.getX()) * percentage;
         float percentageY = (targetPosition.getY() - startingPosition.getY()) * percentage;
         float percentageZ = (targetPosition.getZ() - startingPosition.getZ()) * percentage;
 
-        TardisNavLocation newLocation = new TardisNavLocation(new BlockPos((int) percentageX, (int) percentageY, (int) percentageZ), this.targetLocation.getDirection(), percentage > 0.49f ? this.targetLocation.getLevel() : this.operator.getExteriorManager().getLastKnownLocation().getLevel());
+        TardisNavLocation newLocation = new TardisNavLocation(new BlockPos((int) percentageX, (int) percentageY, (int) percentageZ), this.targetLocation.getDirection(), percentage > 0.49f ? this.targetLocation.getLevel() : this.currentLocation.getLevel());
         this.targetLocation = newLocation;
 
         if (dramatic) {
@@ -625,17 +630,17 @@ public class TardisPilotingManager extends BaseHandler {
         operator.getExteriorManager().removeExteriorBlock();
         this.ticksTakingOff = 0;
         this.operator.getExteriorManager().setIsTakingOff(false);
-        TardisNavLocation lastKnown = operator.getExteriorManager().getLastKnownLocation();
+        TardisNavLocation lastKnown = this.currentLocation;
         TardisEvents.TAKE_OFF.invoker().onTakeOff(operator, lastKnown.getLevel(), lastKnown.getPosition());
 
         if (this.currentConsole != null) {
             operator.getFlightDanceManager().startFlightDance(this.currentConsole);
         }
-
     }
 
     public void onFlightEnd() {
         this.operator.getFlightDanceManager().stopDancing();
+
         this.isInFlight = false;
         this.ticksTakingOff = 0;
         this.autoLand = false;
@@ -672,7 +677,7 @@ public class TardisPilotingManager extends BaseHandler {
         float progress = getFlightPercentageCovered();
 
         Vec3 targetPos = new Vec3(this.targetLocation.getPosition().getX(), this.targetLocation.getPosition().getY(), this.targetLocation.getPosition().getZ());
-        BlockPos currentLoc = tardisExteriorManager.getLastKnownLocation().getPosition();
+        BlockPos currentLoc = this.currentLocation.getPosition();
         Vec3 currentPos = new Vec3(currentLoc.getX(), currentLoc.getY(), currentLoc.getZ());
 
         int x = (int) (currentPos.x + ((targetPos.x - currentPos.x) * progress));
@@ -734,6 +739,13 @@ public class TardisPilotingManager extends BaseHandler {
 
     public void setTargetLocation(TardisNavLocation targetLocation) {
         this.targetLocation = targetLocation;
+    }
+
+    public void setCurrentLocation(TardisNavLocation currentLocation) {
+        this.currentLocation = currentLocation;
+    }
+    public TardisNavLocation getCurrentLocation() {
+        return this.currentLocation;
     }
 
     public void setTargetPosition(BlockPos pos) {

--- a/common/src/main/java/whocraft/tardis_refined/common/util/TardisHelper.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/util/TardisHelper.java
@@ -88,7 +88,7 @@ public class TardisHelper {
                         intManager.generateDesktop(desktopTheme);
                         Direction direction = targetBlockState.getValue(ShellBaseBlock.FACING).getOpposite();
                         TardisNavLocation navLocation = new TardisNavLocation(blockPos, direction, serverLevel);
-                        extManager.setLastKnownLocation(navLocation);
+                        pilotManager.setCurrentLocation(navLocation);
                         pilotManager.setTargetLocation(navLocation);
                         tardisLevelOperator.setInitiallyGenerated(true);
                         serverLevel.setBlock(blockPos, targetBlockState.setValue(ShellBaseBlock.OPEN, true), Block.UPDATE_ALL);

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
@@ -27,6 +27,7 @@ import whocraft.tardis_refined.common.blockentity.door.TardisInternalDoor;
 import whocraft.tardis_refined.common.capability.TardisLevelOperator;
 import whocraft.tardis_refined.common.dimension.DimensionHandler;
 import whocraft.tardis_refined.common.tardis.TardisNavLocation;
+import whocraft.tardis_refined.common.tardis.manager.TardisPilotingManager;
 import whocraft.tardis_refined.common.tardis.themes.ShellTheme;
 import whocraft.tardis_refined.compat.ModCompatChecker;
 import whocraft.tardis_refined.registry.TRDimensionTypes;
@@ -175,7 +176,10 @@ public class ImmersivePortals {
             return;
         }
 
-        TardisNavLocation location = operator.getPilotingManager().getCurrentLocation();
+        TardisPilotingManager pilotingManager = operator.getPilotingManager();
+
+
+        TardisNavLocation location = pilotingManager.getCurrentLocation();
         BlockPos entryPositionBPos = door.getEntryPosition();
         Vec3 entryPosition = new Vec3(entryPositionBPos.getX() + 0.5, entryPositionBPos.getY() + 1, entryPositionBPos.getZ() + 0.5);
         BlockPos exteriorEntryBPos = location.getPosition();
@@ -183,6 +187,9 @@ public class ImmersivePortals {
 
         theme = operator.getAestheticHandler().getShellTheme();
         PortalOffets themeData = themeToOffsetMap.get(theme);
+
+        Level operatorLevel = operator.getLevel();
+
 
         switch (location.getDirection()) {
             case EAST -> exteriorEntryPosition = exteriorEntryPosition.add(themeData.shell().east());
@@ -199,11 +206,11 @@ public class ImmersivePortals {
         DQuaternion extQuat = DQuaternion.rotationByDegrees(new Vec3(0, -1, 0), location.getDirection().toYRot());
         DQuaternion interiorQuat = DQuaternion.rotationByDegrees(new Vec3(0, -1, 0), door.getEntryRotation().toYRot());
 
-        Portal exteriorPortal = createPortal(operator.getPilotingManager().getCurrentLocation().getLevel(), exteriorEntryPosition, entryPosition, operator.getLevel().dimension(), extQuat);
+        Portal exteriorPortal = createPortal(location.getLevel(), exteriorEntryPosition, entryPosition, operatorLevel.dimension(), extQuat);
         Portal interiorPortal = createDestPortal(exteriorPortal, entryPosition, retrievePortalType(), interiorQuat);
 
 
-        tardisToPortalsMap.put(UUID.fromString(operator.getLevel().dimension().location().getPath()), List.of(exteriorPortal, interiorPortal));
+        tardisToPortalsMap.put(UUID.fromString(operatorLevel.dimension().location().getPath()), List.of(exteriorPortal, interiorPortal));
 
         PortalManipulation.adjustRotationToConnect(exteriorPortal, interiorPortal);
         exteriorPortal.setInteractable(false);

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
@@ -175,7 +175,7 @@ public class ImmersivePortals {
             return;
         }
 
-        TardisNavLocation location = operator.getExteriorManager().getLastKnownLocation();
+        TardisNavLocation location = operator.getPilotingManager().getCurrentLocation();
         BlockPos entryPositionBPos = door.getEntryPosition();
         Vec3 entryPosition = new Vec3(entryPositionBPos.getX() + 0.5, entryPositionBPos.getY() + 1, entryPositionBPos.getZ() + 0.5);
         BlockPos exteriorEntryBPos = location.getPosition();
@@ -199,7 +199,7 @@ public class ImmersivePortals {
         DQuaternion extQuat = DQuaternion.rotationByDegrees(new Vec3(0, -1, 0), location.getDirection().toYRot());
         DQuaternion interiorQuat = DQuaternion.rotationByDegrees(new Vec3(0, -1, 0), door.getEntryRotation().toYRot());
 
-        Portal exteriorPortal = createPortal(operator.getExteriorManager().getLevel(), exteriorEntryPosition, entryPosition, operator.getLevel().dimension(), extQuat);
+        Portal exteriorPortal = createPortal(operator.getPilotingManager().getCurrentLocation().getLevel(), exteriorEntryPosition, entryPosition, operator.getLevel().dimension(), extQuat);
         Portal interiorPortal = createDestPortal(exteriorPortal, entryPosition, retrievePortalType(), interiorQuat);
 
 

--- a/common/src/main/java/whocraft/tardis_refined/constants/ModMessages.java
+++ b/common/src/main/java/whocraft/tardis_refined/constants/ModMessages.java
@@ -46,6 +46,9 @@ public class ModMessages {
     public static String WAYPOINT_LOADED = message("waypoint_loaded");
     public static String CANNOT_START_NO_FUEL = message("cannot_start_no_fuel");
 
+    public static String CURRENT = message("current");
+    public static String DESTINATION = message("destination");
+
 
 
     public static String TOOLTIP_TARDIS_LIST_TITLE = tooltip("tardis_list");

--- a/forge/src/main/java/whocraft/tardis_refined/common/data/LangProviderEnglish.java
+++ b/forge/src/main/java/whocraft/tardis_refined/common/data/LangProviderEnglish.java
@@ -136,6 +136,8 @@ public class LangProviderEnglish extends LanguageProvider {
         add(ModMessages.WAYPOINT_LOADED, "Preloaded waypoint: %s");
         add(ModMessages.HANDBRAKE_ENGAGED, "Handbrake engaged");
         add(ModMessages.HANDBRAKE_DISENGAGED, "Handbrake disengaged");
+        add(ModMessages.CURRENT, "CURRENT");
+        add(ModMessages.DESTINATION, "DESTINATION");
 
 
         /*Command*/


### PR DESCRIPTION
This PR removes the LastKnownLocation from the exterior manager and moves it to the Piloting manager under the new name "CurrentLocation".

Made entering a TARDIS update the currentLocation.
Made flight set the current location when the ship lands.
Re-worked @Jeryn99's logic for removing duplicate shells, adding a failsafe so if there's no recorded current value we make that shell the new value. 