### PR TITLE
TardisClientData is a Sin

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/api/event/TardisClientEvents.java
+++ b/common/src/main/java/whocraft/tardis_refined/api/event/TardisClientEvents.java
@@ -1,0 +1,19 @@
+package whocraft.tardis_refined.api.event;
+
+import net.minecraft.client.model.geom.EntityModelSet;
+
+public class TardisClientEvents {
+
+    public static final Event<TardisClientEvents.SetupModels> SHELLENTRY_MODELS_SETUP = new Event<>(TardisClientEvents.SetupModels.class, listeners -> (EntityModelSet context) -> {
+        for(TardisClientEvents.SetupModels listener : listeners) {
+            listener.setUpShellAndInteriorModels(context);
+        }
+    });
+
+    @FunctionalInterface
+    public interface SetupModels {
+        void setUpShellAndInteriorModels(EntityModelSet context);
+    }
+
+
+}

--- a/common/src/main/java/whocraft/tardis_refined/api/event/TardisCommonEvents.java
+++ b/common/src/main/java/whocraft/tardis_refined/api/event/TardisCommonEvents.java
@@ -1,22 +1,16 @@
 package whocraft.tardis_refined.api.event;
 
-import net.minecraft.client.model.geom.EntityModelSet;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
-import whocraft.tardis_refined.common.blockentity.door.TardisInternalDoor;
 import whocraft.tardis_refined.common.capability.TardisLevelOperator;
 import whocraft.tardis_refined.common.capability.upgrades.Upgrade;
 import whocraft.tardis_refined.common.entity.ControlEntity;
-import whocraft.tardis_refined.common.tardis.ExteriorShell;
 import whocraft.tardis_refined.common.tardis.TardisNavLocation;
 import whocraft.tardis_refined.common.tardis.control.Control;
 
-public class TardisEvents {
+public class TardisCommonEvents {
 
     public static final Event<TakeOff> TAKE_OFF = new Event<>(TakeOff.class, listeners -> (tardisLevelOperator, level, pos) -> Event.result(listeners, takeOff -> takeOff.onTakeOff(tardisLevelOperator, level, pos)));
 
@@ -68,23 +62,12 @@ public class TardisEvents {
         }
     }));
 
-    public static final Event<SetupModels> SHELLENTRY_MODELS_SETUP = new Event<>(SetupModels.class, listeners -> (EntityModelSet context) -> {
-        for(SetupModels listener : listeners) {
-            listener.setUpShellAndInteriorModels(context);
-        }
-    });
-
 
     /**
      * Represents an event that allows checking whether player control can be used.
      */
     public static final Event<CanControlBeUsed> PLAYER_CONTROL_INTERACT = new Event<>(CanControlBeUsed.class, listeners -> (tardisLevelOperator, control, controlEntity) -> Event.result(listeners, takeOff -> takeOff.canControlBeUsed(tardisLevelOperator, control, controlEntity)));
 
-
-    @FunctionalInterface
-    public interface SetupModels {
-        void setUpShellAndInteriorModels(EntityModelSet context);
-    }
 
 
     /**

--- a/common/src/main/java/whocraft/tardis_refined/client/TardisClientLogic.java
+++ b/common/src/main/java/whocraft/tardis_refined/client/TardisClientLogic.java
@@ -1,0 +1,259 @@
+package whocraft.tardis_refined.client;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.sounds.SoundManager;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import whocraft.tardis_refined.client.sounds.HumSoundManager;
+import whocraft.tardis_refined.client.sounds.LoopingSound;
+import whocraft.tardis_refined.client.sounds.QuickSimpleSound;
+import whocraft.tardis_refined.common.GravityUtil;
+import whocraft.tardis_refined.common.capability.TardisLevelOperator;
+import whocraft.tardis_refined.common.hum.HumEntry;
+import whocraft.tardis_refined.common.hum.TardisHums;
+import whocraft.tardis_refined.common.util.TardisHelper;
+import whocraft.tardis_refined.registry.TRDimensionTypes;
+
+import java.util.List;
+
+import static whocraft.tardis_refined.client.TardisClientData.FOG_TICK_DELTA;
+import static whocraft.tardis_refined.client.TardisClientData.MAX_FOG_TICK_DELTA;
+import static whocraft.tardis_refined.common.util.TardisHelper.isInArsArea;
+import static whocraft.tardis_refined.constants.TardisDimensionConstants.ARS_TREE_CENTER;
+
+public class TardisClientLogic {
+
+
+    /**
+     * Higher means more fog, lower means less fog
+     * @return 0 -> 1 float based off fog tick delta
+     */
+    public static float getFogTickDelta(BlockPos playerPosition) {
+        return TardisHelper.isInArsArea(playerPosition) ? 1f :  1f - (float) FOG_TICK_DELTA / (float) MAX_FOG_TICK_DELTA;
+    }
+
+    public static void tickFog(boolean hasFuel) {
+        if (!hasFuel && (FOG_TICK_DELTA <= MAX_FOG_TICK_DELTA) && (FOG_TICK_DELTA > 0)) {
+            FOG_TICK_DELTA--; // Fading in the fog
+            return;
+        }
+
+        if (hasFuel && (FOG_TICK_DELTA != MAX_FOG_TICK_DELTA)) {
+            FOG_TICK_DELTA++; // Fading out the fog
+            return;
+        }
+    }
+
+
+    @Environment(EnvType.CLIENT)
+    public static void tickClientside(TardisClientData clientData) {
+
+        SoundManager soundManager = Minecraft.getInstance().getSoundManager();
+
+
+        if (clientData.isTakingOff()) {
+            clientData.takeOffTime++;
+            clientData.landingTime = 0;
+            return;
+        }
+
+        if (clientData.isLanding()) {
+            clientData.landingTime++;
+            clientData.takeOffTime = 0;
+        }
+
+
+        if (Minecraft.getInstance().player.level().dimensionTypeId() == TRDimensionTypes.TARDIS) {
+
+            ClientLevel tardisLevel = Minecraft.getInstance().level;
+            boolean isThisTardis = clientData.getLevelKey() == tardisLevel.dimension();
+
+            createWorldAmbience(Minecraft.getInstance().player);
+
+            if (LoopingSound.ARS_HUMMING == null) {
+                LoopingSound.setupSounds();
+            }
+
+            if (isInArsArea(Minecraft.getInstance().player.blockPosition())) {
+                if (!soundManager.isActive(LoopingSound.ARS_HUMMING)) {
+                    LoopingSound.ARS_HUMMING.setLocation(ARS_TREE_CENTER);
+                    soundManager.play(LoopingSound.ARS_HUMMING);
+                }
+            }
+
+            if (isThisTardis && clientData.isFlying()) {
+                if (!soundManager.isActive(LoopingSound.FLIGHT_LOOP)) {
+                    soundManager.play(LoopingSound.FLIGHT_LOOP);
+                }
+            }
+
+            HumEntry humEntry = clientData.getHumEntry();
+            if (isThisTardis && humEntry != null && !humEntry.getSound().toString().equals(HumSoundManager.getCurrentRawSound().getLocation().toString()) || !soundManager.isActive(HumSoundManager.getCurrentSound())) {
+                HumSoundManager.playHum(SoundEvent.createVariableRangeEvent(humEntry.getSound()));
+            }
+
+            if (isThisTardis && tardisLevel.getGameTime() % clientData.nextAmbientNoiseCall == 0) {
+
+
+                clientData.nextAmbientNoiseCall = tardisLevel.random.nextInt(400, 2400);
+                List<ResourceLocation> ambientSounds = humEntry.getAmbientSounds();
+                if (ambientSounds != null && !ambientSounds.isEmpty()) {
+                    RandomSource randomSource = tardisLevel.random;
+
+                    ResourceLocation randomSoundLocation = ambientSounds.get(randomSource.nextInt(ambientSounds.size()));
+                    SoundEvent randomSoundEvent = SoundEvent.createVariableRangeEvent(randomSoundLocation);
+
+                    QuickSimpleSound simpleSoundInstance = new QuickSimpleSound(randomSoundEvent, SoundSource.AMBIENT);
+                    simpleSoundInstance.setVolume(0.3F);
+
+                    playAmbientSound(simpleSoundInstance, randomSource, 0.3f);
+
+                }
+            }
+
+            if (LoopingSound.shouldMinecraftMusicStop(soundManager)) {
+                Minecraft.getInstance().getMusicManager().stopPlaying();
+            }
+
+
+
+            if (isThisTardis && tardisLevel.getGameTime() % clientData.nextVoiceAmbientCall == 0) {
+                clientData.nextVoiceAmbientCall = tardisLevel.random.nextInt(6000, 36000);
+
+                RandomSource randomSource = tardisLevel.random;
+                playAmbientSound(QuickSimpleSound.VOICE_QUICK_SOUND, randomSource, 0.3f);
+            }
+
+
+            // Responsible for screen-shake. Not sure of a better solution at this point in time.
+
+            if (Minecraft.getInstance().player.level().dimension() == clientData.getLevelKey()) {
+                var player = Minecraft.getInstance().player;
+                if (clientData.isCrashing()) {
+                    player.setXRot(player.getXRot() + (player.getRandom().nextFloat() - 0.5f) * 0.5f);
+                    player.setYHeadRot(player.getYHeadRot() + (player.getRandom().nextFloat() - 0.5f) *  0.5f);
+                } else {
+                    if (clientData.isFlying()) {
+                        player.setXRot(player.getXRot() + (player.getRandom().nextFloat() - 0.5f) * (clientData.getThrottleStage() * 0.1f));
+                        player.setYHeadRot(player.getYHeadRot() + (player.getRandom().nextFloat() - 0.5f) * (clientData.getThrottleStage() * 0.1f));
+                    }
+                }
+            }
+
+            if (isThisTardis) {
+                tickFog(  clientData.getTardisState() < TardisLevelOperator.STATE_EYE_OF_HARMONY || clientData.getFuel() != 0);
+            }
+
+            if (isThisTardis && clientData.getTardisState() == TardisLevelOperator.STATE_EYE_OF_HARMONY) {
+                tardisLevel.addParticle(ParticleTypes.CLOUD, (double)1013 + 0.5 - 2 + tardisLevel.random.nextInt(4), 71, (double)55 + 0.5- 2 + tardisLevel.random.nextInt(4),0, 0.1 + tardisLevel.random.nextFloat() / 2 ,0);
+            }
+        }
+
+    }
+
+    public static void playAmbientSound(QuickSimpleSound sound, RandomSource randomSource, float volume) {
+        sound.setVolume(volume);
+        LocalPlayer player = Minecraft.getInstance().player;
+        double randomX = player.getX() + (randomSource.nextDouble() - 0.5) * 100;
+        double randomY = player.getY() + (randomSource.nextDouble() - 0.5) * 100;
+        double randomZ = player.getZ() + (randomSource.nextDouble() - 0.5) * 100;
+        sound.setLocation(new Vec3(randomX, randomY, randomZ));
+        Minecraft.getInstance().getSoundManager().play(sound);
+    }
+
+    /**
+     * Updates the Tardis instance. This method is called manually from the SyncIntReactionsMessage message.
+     */
+    public static void update(TardisClientData tardisClientData) {
+        // Check if the Tardis is not currently flying and the rotor animation is started
+        if (!tardisClientData.isFlying() && tardisClientData.ROTOR_ANIMATION.isStarted()) {
+            tardisClientData.ROTOR_ANIMATION.stop();
+        }
+        // Check if the Tardis is flying and the rotor animation is not started
+        else if (tardisClientData.isFlying() && !tardisClientData.ROTOR_ANIMATION.isStarted()) {
+            tardisClientData.ROTOR_ANIMATION.start(0);
+        }
+
+        if (tardisClientData.isLanding()) {
+            if (!tardisClientData.LANDING_ANIMATION.isStarted()) {
+                tardisClientData.TAKEOFF_ANIMATION.stop();
+                tardisClientData.LANDING_ANIMATION.start(0);
+            }
+        } else if (tardisClientData.LANDING_ANIMATION.isStarted()) {
+            tardisClientData.LANDING_ANIMATION.stop();
+        }
+
+        if (tardisClientData.isTakingOff()) {
+            if (!tardisClientData.TAKEOFF_ANIMATION.isStarted()) {
+                tardisClientData.LANDING_ANIMATION.stop();
+                tardisClientData.TAKEOFF_ANIMATION.start(0);
+            }
+        } else if (tardisClientData.TAKEOFF_ANIMATION.isStarted()) {
+            tardisClientData.TAKEOFF_ANIMATION.stop();
+        }
+    }
+
+    /**
+     * Called by platform-specific methods
+     *
+     * @param client Minecraft client
+     */
+    public static void tickClientData(Minecraft client) {
+        // Inelegant solution, please revise
+        if (client.level == null || client.isPaused()) {
+            if (!TardisClientData.getAllEntries().isEmpty() && !client.isPaused()) {
+                TardisClientData.clearAll();
+            }
+            return;
+        }
+
+        SoundManager soundManager = Minecraft.getInstance().getSoundManager();
+
+        if (LoopingSound.ARS_HUMMING == null) {
+            LoopingSound.setupSounds();
+        }
+
+        if (GravityUtil.isInGravityShaft(Minecraft.getInstance().player)) {
+            if (!soundManager.isActive(LoopingSound.GRAVITY_LOOP)) {
+                soundManager.play(LoopingSound.GRAVITY_LOOP);
+            }
+        }
+
+        TardisClientData.getAllEntries().forEach((levelResourceKey, tardisClientData) -> TardisClientLogic.tickClientside(tardisClientData));
+    }
+
+    private static void createWorldAmbience(Player player) {
+        if (player.tickCount % 120 == 0 && !isInArsArea(player.blockPosition())) return;
+        RandomSource random = player.level().random;
+        Level level = player.level();
+        double originX = player.getX();
+        double originY = player.getY();
+        double originZ = player.getZ();
+        for (int i = 0; i < 5; i++) {
+            double particleX = originX + (random.nextInt(24) - random.nextInt(24));
+            double particleY = originY + (random.nextInt(24) - random.nextInt(24));
+            double particleZ = originZ + (random.nextInt(24) - random.nextInt(24));
+            double velocityX = (random.nextDouble() - 0.5) * 0.02;
+            double velocityY = (random.nextDouble() - 0.5) * 0.02;
+            double velocityZ = (random.nextDouble() - 0.5) * 0.02;
+            if (isInArsArea(new BlockPos((int) particleX, (int) particleY, (int) particleZ))) {
+                level.addParticle(TRParticles.ARS_LEAVES.get(), particleX, particleY, particleZ, velocityX, velocityY, velocityZ);
+                level.addParticle(ParticleTypes.END_ROD, particleX, particleY, particleZ, velocityX, velocityY, velocityZ);
+            }
+        }
+    }
+
+
+
+}

--- a/common/src/main/java/whocraft/tardis_refined/client/model/blockentity/shell/ShellModelCollection.java
+++ b/common/src/main/java/whocraft/tardis_refined/client/model/blockentity/shell/ShellModelCollection.java
@@ -3,8 +3,8 @@ package whocraft.tardis_refined.client.model.blockentity.shell;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.geom.EntityModelSet;
 import net.minecraft.resources.ResourceLocation;
-import whocraft.tardis_refined.TardisRefined;
-import whocraft.tardis_refined.api.event.TardisEvents;
+import whocraft.tardis_refined.api.event.TardisClientEvents;
+import whocraft.tardis_refined.api.event.TardisCommonEvents;
 import whocraft.tardis_refined.client.ModelRegistry;
 import whocraft.tardis_refined.client.model.blockentity.door.interior.*;
 import whocraft.tardis_refined.client.model.blockentity.shell.shells.*;
@@ -73,7 +73,7 @@ public class ShellModelCollection {
         pathfinderDoorModel = new PathfinderDoorModel(context.bakeLayer((ModelRegistry.PATHFINDER_DOOR)));
         halfBakedDoorModel = new HalfBakedDoorModel(context.bakeLayer((ModelRegistry.HALF_BAKED_DOOR)));
 
-        TardisEvents.SHELLENTRY_MODELS_SETUP.invoker().setUpShellAndInteriorModels(context);
+        TardisClientEvents.SHELLENTRY_MODELS_SETUP.invoker().setUpShellAndInteriorModels(context);
 
         registerShellEntry(ShellTheme.FACTORY.get(), factoryShellModel, factoryDoorModel);
         registerShellEntry(ShellTheme.POLICE_BOX.get(), policeBoxModel, policeBoxDoorModel);

--- a/common/src/main/java/whocraft/tardis_refined/client/sounds/QuickSimpleSound.java
+++ b/common/src/main/java/whocraft/tardis_refined/client/sounds/QuickSimpleSound.java
@@ -8,8 +8,12 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
+import whocraft.tardis_refined.registry.TRSoundRegistry;
 
 public class QuickSimpleSound extends AbstractTickableSoundInstance {
+
+    public static QuickSimpleSound VOICE_QUICK_SOUND =  new QuickSimpleSound(TRSoundRegistry.INTERIOR_VOICE.get(), SoundSource.AMBIENT);
+
 
     public QuickSimpleSound(@NotNull SoundEvent soundEvent, SoundSource soundSource) {
         super(soundEvent, soundSource, SoundInstance.createUnseededRandom());

--- a/common/src/main/java/whocraft/tardis_refined/common/GravityClient.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/GravityClient.java
@@ -1,0 +1,39 @@
+package whocraft.tardis_refined.common;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.Options;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static whocraft.tardis_refined.common.GravityUtil.easeMovement;
+
+public class GravityClient {
+
+    public static void moveGravity(Player player, CallbackInfo info) {
+        Vec3 deltaMovement = player.getDeltaMovement();
+        Minecraft minecraft = Minecraft.getInstance();
+        Options options = minecraft.options;
+
+        if (GravityUtil.isInGravityShaft(player)) {
+            player.resetFallDistance();
+            player.setNoGravity(true);
+            player.setPose(Pose.STANDING);
+
+            if (options.keyJump.isDown()) {
+                player.setDeltaMovement(deltaMovement.add(0, easeMovement(), 0));
+                info.cancel();
+            } else if (options.keyShift.isDown()) {
+                player.setDeltaMovement(deltaMovement.add(0, -easeMovement(), 0));
+                info.cancel();
+            } else {
+                player.setDeltaMovement(deltaMovement.x, 0, deltaMovement.z);
+            }
+        } else {
+            player.setNoGravity(false);
+        }
+    }
+
+
+}

--- a/common/src/main/java/whocraft/tardis_refined/common/GravityUtil.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/GravityUtil.java
@@ -67,33 +67,8 @@ public class GravityUtil {
         return isInAntiGrav(player, player.getBoundingBox().inflate(8, MAX_Y, 8), player.level());
     }
 
-    @Environment(EnvType.CLIENT)
-    public static void moveGravity(Player player, CallbackInfo info) {
-        Vec3 deltaMovement = player.getDeltaMovement();
-        Minecraft minecraft = Minecraft.getInstance();
-        Options options = minecraft.options;
 
-        if (isInGravityShaft(player)) {
-            player.resetFallDistance();
-            player.setNoGravity(true);
-            player.setPose(Pose.STANDING);
-
-            if (options.keyJump.isDown()) {
-                player.setDeltaMovement(deltaMovement.add(0, easeMovement(), 0));
-                info.cancel();
-            } else if (options.keyShift.isDown()) {
-                player.setDeltaMovement(deltaMovement.add(0, -easeMovement(), 0));
-                info.cancel();
-            } else {
-                player.setDeltaMovement(deltaMovement.x, 0, deltaMovement.z);
-            }
-        } else {
-            player.setNoGravity(false);
-        }
-    }
-
-
-    private static double easeMovement() {
+    static double easeMovement() {
         double smoothedMovement = Math.abs(GravityUtil.ACCELERATION);
         return smoothedMovement * smoothedMovement * smoothedMovement;
     }

--- a/common/src/main/java/whocraft/tardis_refined/common/capability/TardisLevelOperator.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/capability/TardisLevelOperator.java
@@ -10,25 +10,19 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import whocraft.tardis_refined.api.event.TardisEvents;
+import whocraft.tardis_refined.api.event.TardisCommonEvents;
 import whocraft.tardis_refined.client.TardisClientData;
 import whocraft.tardis_refined.common.block.shell.ShellBaseBlock;
-import whocraft.tardis_refined.common.blockentity.door.AbstractDoorBlockEntity;
 import whocraft.tardis_refined.common.blockentity.door.RootShellDoorBlockEntity;
 import whocraft.tardis_refined.common.blockentity.door.TardisInternalDoor;
-import whocraft.tardis_refined.common.blockentity.shell.ShellBaseBlockEntity;
 import whocraft.tardis_refined.common.capability.upgrades.UpgradeHandler;
-import whocraft.tardis_refined.common.hum.HumEntry;
 import whocraft.tardis_refined.common.hum.TardisHums;
 import whocraft.tardis_refined.common.tardis.ExteriorShell;
 import whocraft.tardis_refined.common.tardis.TardisArchitectureHandler;
 import whocraft.tardis_refined.common.tardis.TardisDesktops;
 import whocraft.tardis_refined.common.tardis.TardisNavLocation;
 import whocraft.tardis_refined.common.tardis.manager.*;
-import whocraft.tardis_refined.common.tardis.themes.DesktopTheme;
 import whocraft.tardis_refined.common.util.TardisHelper;
 import whocraft.tardis_refined.compat.ModCompatChecker;
 import whocraft.tardis_refined.compat.portals.ImmersivePortals;
@@ -36,7 +30,6 @@ import whocraft.tardis_refined.constants.NbtConstants;
 
 import java.util.Optional;
 
-import static whocraft.tardis_refined.common.block.RootPlantBlock.FACING;
 import static whocraft.tardis_refined.common.block.shell.ShellBaseBlock.OPEN;
 
 public class TardisLevelOperator {
@@ -253,9 +246,9 @@ public class TardisLevelOperator {
             intDoor.setClosed(closeDoor);
         }
         if (closeDoor) {
-            TardisEvents.DOOR_CLOSED_EVENT.invoker().onDoorClosed(this);
+            TardisCommonEvents.DOOR_CLOSED_EVENT.invoker().onDoorClosed(this);
         } else {
-            TardisEvents.DOOR_OPENED_EVENT.invoker().onDoorOpen(this);
+            TardisCommonEvents.DOOR_OPENED_EVENT.invoker().onDoorOpen(this);
         }
 
         if (this.pilotingManager != null) {
@@ -270,7 +263,7 @@ public class TardisLevelOperator {
         tardisClientData.setShellTheme(theme);
         tardisClientData.setShellPattern(aestheticHandler.shellPattern().id());
         tardisClientData.sync();
-        TardisEvents.SHELL_CHANGE_EVENT.invoker().onShellChange(this, theme, setupTardis);
+        TardisCommonEvents.SHELL_CHANGE_EVENT.invoker().onShellChange(this, theme, setupTardis);
     }
 
     /**

--- a/common/src/main/java/whocraft/tardis_refined/common/capability/upgrades/UpgradeHandler.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/capability/upgrades/UpgradeHandler.java
@@ -8,7 +8,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
 import org.jetbrains.annotations.NotNull;
-import whocraft.tardis_refined.api.event.TardisEvents;
+import whocraft.tardis_refined.api.event.TardisCommonEvents;
 import whocraft.tardis_refined.common.capability.TardisLevelOperator;
 
 import java.util.ArrayList;
@@ -160,7 +160,7 @@ public class UpgradeHandler {
                 generateArsTree(tardisLevelOperator, serverLevel);
             }
 
-            TardisEvents.UPGRADE_UNLOCKED.invoker().onUpgradeUnlock(this.tardisLevelOperator, upgrade);
+            TardisCommonEvents.UPGRADE_UNLOCKED.invoker().onUpgradeUnlock(this.tardisLevelOperator, upgrade);
 
         }
     }

--- a/common/src/main/java/whocraft/tardis_refined/common/hum/TardisHums.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/hum/TardisHums.java
@@ -1,7 +1,9 @@
 package whocraft.tardis_refined.common.hum;
 
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundSource;
 import whocraft.tardis_refined.TardisRefined;
+import whocraft.tardis_refined.client.sounds.QuickSimpleSound;
 import whocraft.tardis_refined.common.util.CodecJsonReloadListener;
 import whocraft.tardis_refined.registry.TRSoundRegistry;
 
@@ -10,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class TardisHums {
+
 
     private static final CodecJsonReloadListener<HumEntry> RELOAD_LISTENER = createReloadListener();
 

--- a/common/src/main/java/whocraft/tardis_refined/common/mixin/FogRendererMixin.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/mixin/FogRendererMixin.java
@@ -14,6 +14,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import whocraft.tardis_refined.client.TardisClientData;
+import whocraft.tardis_refined.client.TardisClientLogic;
 import whocraft.tardis_refined.common.util.TardisHelper;
 import whocraft.tardis_refined.registry.TRDimensionTypes;
 
@@ -44,8 +45,8 @@ public class FogRendererMixin {
 
             TardisClientData reactions = TardisClientData.getInstance(level.dimension());
 
-            if (TardisClientData.getFogTickDelta(blockPosition) > 0.0f) {
-                float delta = TardisClientData.getFogTickDelta(blockPosition);
+            if (TardisClientLogic.getFogTickDelta(blockPosition) > 0.0f) {
+                float delta = TardisClientLogic.getFogTickDelta(blockPosition);
 
                 RenderSystem.setShaderFogColor(0, 0, 0, 1); // This sets the fog to a pitch black
                 RenderSystem.setShaderFogStart(Mth.lerp(delta, 16f, -8f)); // This positions the fog based off the delta

--- a/common/src/main/java/whocraft/tardis_refined/common/mixin/PlayerEntityMixin.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/mixin/PlayerEntityMixin.java
@@ -7,6 +7,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import whocraft.tardis_refined.common.GravityClient;
 import whocraft.tardis_refined.common.GravityUtil;
 
 @Mixin(Player.class)
@@ -15,7 +16,8 @@ public class PlayerEntityMixin {
     @Inject(method = "travel(Lnet/minecraft/world/phys/Vec3;)V", at = @At("TAIL"), cancellable = true)
     private void move(Vec3 vec3, CallbackInfo info) {
         Player player = (Player) (Object) this;
-        GravityUtil.moveGravity(player, info);
+        if(!player.level().isClientSide) return;
+        GravityClient.moveGravity(player, info);
     }
 
 

--- a/common/src/main/java/whocraft/tardis_refined/common/network/messages/sync/SyncHumsMessage.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/network/messages/sync/SyncHumsMessage.java
@@ -39,7 +39,7 @@ public class SyncHumsMessage extends MessageS2C {
 
     @Override
     public void toBytes(FriendlyByteBuf buf) {
-        buf.writeNbt((CompoundTag) (MAPPER.encodeStart(NbtOps.INSTANCE, this.tardisHums).result().orElse(new CompoundTag())));
+        buf.writeNbt(MAPPER.encodeStart(NbtOps.INSTANCE, this.tardisHums).result().orElse(new CompoundTag()));
     }
 
     @Override

--- a/common/src/main/java/whocraft/tardis_refined/common/network/messages/sync/SyncTardisClientDataMessage.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/network/messages/sync/SyncTardisClientDataMessage.java
@@ -7,6 +7,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 import whocraft.tardis_refined.client.TardisClientData;
+import whocraft.tardis_refined.client.TardisClientLogic;
 import whocraft.tardis_refined.common.network.MessageContext;
 import whocraft.tardis_refined.common.network.MessageS2C;
 import whocraft.tardis_refined.common.network.MessageType;
@@ -48,6 +49,6 @@ public class SyncTardisClientDataMessage extends MessageS2C {
         data.deserializeNBT(compoundTag);
 
         // Update the Tardis instance
-        data.update();
+        TardisClientLogic.update(data);
     }
 }

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/control/Control.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/control/Control.java
@@ -6,7 +6,7 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.player.Player;
 import whocraft.tardis_refined.api.event.EventResult;
-import whocraft.tardis_refined.api.event.TardisEvents;
+import whocraft.tardis_refined.api.event.TardisCommonEvents;
 import whocraft.tardis_refined.common.capability.TardisLevelOperator;
 import whocraft.tardis_refined.common.entity.ControlEntity;
 import whocraft.tardis_refined.common.tardis.themes.ConsoleTheme;
@@ -74,7 +74,7 @@ public abstract class Control {
 
     public boolean canUseControl(TardisLevelOperator tardisLevelOperator, Control control, ControlEntity controlEntity){
         boolean isDeskopWaiting = controlEntity.isDesktopWaitingToGenerate(tardisLevelOperator);
-        return !isDeskopWaiting && TardisEvents.PLAYER_CONTROL_INTERACT.invoker().canControlBeUsed(tardisLevelOperator, control, controlEntity) == EventResult.pass();
+        return !isDeskopWaiting && TardisCommonEvents.PLAYER_CONTROL_INTERACT.invoker().canControlBeUsed(tardisLevelOperator, control, controlEntity) == EventResult.pass();
     }
 
     public ResourceLocation getId(){

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -18,7 +18,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
-import whocraft.tardis_refined.api.event.TardisEvents;
+import whocraft.tardis_refined.api.event.TardisCommonEvents;
 import whocraft.tardis_refined.common.block.console.GlobalConsoleBlock;
 import whocraft.tardis_refined.common.blockentity.console.GlobalConsoleBlockEntity;
 import whocraft.tardis_refined.common.capability.TardisLevelOperator;
@@ -634,7 +634,7 @@ public class TardisPilotingManager extends BaseHandler {
         this.ticksTakingOff = 0;
         this.operator.getExteriorManager().setIsTakingOff(false);
         TardisNavLocation lastKnown = this.currentLocation;
-        TardisEvents.TAKE_OFF.invoker().onTakeOff(operator, lastKnown.getLevel(), lastKnown.getPosition());
+        TardisCommonEvents.TAKE_OFF.invoker().onTakeOff(operator, lastKnown.getLevel(), lastKnown.getPosition());
 
         if (this.currentConsole != null) {
             operator.getFlightDanceManager().startFlightDance(this.currentConsole);
@@ -652,7 +652,7 @@ public class TardisPilotingManager extends BaseHandler {
             this.operator.getLevel().playSound(null, this.currentConsoleBlockPos, TRSoundRegistry.LOW_FUEL.get(), SoundSource.AMBIENT, 1000, 1 );
         }
 
-        TardisEvents.LAND.invoker().onLand(operator, getTargetLocation().getLevel(), getTargetLocation().getPosition());
+        TardisCommonEvents.LAND.invoker().onLand(operator, getTargetLocation().getLevel(), getTargetLocation().getPosition());
     }
 
     // Triggers the crash event.
@@ -705,7 +705,7 @@ public class TardisPilotingManager extends BaseHandler {
         this.ticksSinceCrash = 1;
 
         onFlightEnd();
-        TardisEvents.TARDIS_CRASH_EVENT.invoker().onTardisCrash(this.operator, this.targetLocation);
+        TardisCommonEvents.TARDIS_CRASH_EVENT.invoker().onTardisCrash(this.operator, this.targetLocation);
     }
 
     public float getFlightPercentageCovered() {

--- a/common/src/main/java/whocraft/tardis_refined/common/util/TardisHelper.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/util/TardisHelper.java
@@ -15,7 +15,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.Vec3;
-import whocraft.tardis_refined.api.event.TardisEvents;
+import whocraft.tardis_refined.api.event.TardisCommonEvents;
 import whocraft.tardis_refined.common.block.shell.GlobalShellBlock;
 import whocraft.tardis_refined.common.block.shell.ShellBaseBlock;
 import whocraft.tardis_refined.common.blockentity.shell.GlobalShellBlockEntity;
@@ -148,9 +148,9 @@ public class TardisHelper {
             //Fire exit or enter events
             if (entity instanceof LivingEntity livingEntity) {
                 if (enterTardis) {
-                    TardisEvents.TARDIS_ENTRY_EVENT.invoker().onEnterTardis(cap, livingEntity, sourceLocation, destinationLocation);
+                    TardisCommonEvents.TARDIS_ENTRY_EVENT.invoker().onEnterTardis(cap, livingEntity, sourceLocation, destinationLocation);
                 } else {
-                    TardisEvents.TARDIS_EXIT_EVENT.invoker().onExitTardis(cap, livingEntity, sourceLocation, destinationLocation);
+                    TardisCommonEvents.TARDIS_EXIT_EVENT.invoker().onExitTardis(cap, livingEntity, sourceLocation, destinationLocation);
                 }
             }
 

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
@@ -22,7 +22,7 @@ import qouteall.q_misc_util.MiscHelper;
 import qouteall.q_misc_util.api.DimensionAPI;
 import qouteall.q_misc_util.my_util.DQuaternion;
 import whocraft.tardis_refined.TardisRefined;
-import whocraft.tardis_refined.api.event.TardisEvents;
+import whocraft.tardis_refined.api.event.TardisCommonEvents;
 import whocraft.tardis_refined.common.blockentity.door.TardisInternalDoor;
 import whocraft.tardis_refined.common.capability.TardisLevelOperator;
 import whocraft.tardis_refined.common.dimension.DimensionHandler;
@@ -63,9 +63,9 @@ public class ImmersivePortals {
     public static void init() {
         if (!ModCompatChecker.immersivePortals()) return;
         TardisRefined.LOGGER.info("Immersive Portals Detected - Setting up Compatibility");
-        TardisEvents.DOOR_OPENED_EVENT.register(ImmersivePortals::createPortals);
-        TardisEvents.DOOR_CLOSED_EVENT.register(ImmersivePortals::destroyPortals);
-        TardisEvents.SHELL_CHANGE_EVENT.register((operator, theme, isSetupTardis) -> {
+        TardisCommonEvents.DOOR_OPENED_EVENT.register(ImmersivePortals::createPortals);
+        TardisCommonEvents.DOOR_CLOSED_EVENT.register(ImmersivePortals::destroyPortals);
+        TardisCommonEvents.SHELL_CHANGE_EVENT.register((operator, theme, isSetupTardis) -> {
             ImmersivePortals.destroyPortals(operator);
             if (operator.getInternalDoor() != null){
                 if (operator.getInternalDoor().isOpen()) {

--- a/fabric/src/main/java/whocraft/tardis_refined/fabric/events/ModEvents.java
+++ b/fabric/src/main/java/whocraft/tardis_refined/fabric/events/ModEvents.java
@@ -13,6 +13,7 @@ import whocraft.tardis_refined.ControlGroupCheckers;
 import whocraft.tardis_refined.client.GravityOverlay;
 import whocraft.tardis_refined.client.TRItemColouring;
 import whocraft.tardis_refined.client.TardisClientData;
+import whocraft.tardis_refined.client.TardisClientLogic;
 import whocraft.tardis_refined.command.TardisRefinedCommand;
 import whocraft.tardis_refined.common.capability.TardisLevelOperator;
 import whocraft.tardis_refined.common.crafting.ManipulatorCrafting;
@@ -54,7 +55,7 @@ public class ModEvents {
     }
 
     public static void addClientEvents() {
-        ClientTickEvents.START_CLIENT_TICK.register(TardisClientData::tickClientData);
+        ClientTickEvents.START_CLIENT_TICK.register(TardisClientLogic::tickClientData);
         ColorProviderRegistry.ITEM.register(TRItemColouring.SCREWDRIVER_COLORS, TRItemRegistry.SCREWDRIVER.get());
         HudRenderCallback.EVENT.register((matrixStack, tickDelta) -> GravityOverlay.renderOverlay(matrixStack.pose()));
     }

--- a/forge/src/main/java/whocraft/tardis_refined/common/data/LangProviderEnglish.java
+++ b/forge/src/main/java/whocraft/tardis_refined/common/data/LangProviderEnglish.java
@@ -125,7 +125,7 @@ public class LangProviderEnglish extends LanguageProvider {
         add(ModMessages.NO_END_DRAGON_PREVENTS, "A dragon prevents you from progressing to The End");
         add(ModMessages.TARDIS_IS_ON_THE_WAY, "TARDIS has been summoned and is on the way");
         add(ModMessages.LANDING_PAD_NOT_UNLOCKED, "Specified TARDIS rejected landing pad signal");
-        add(ModMessages.LANDING_PAD_TRANSIENT, "Cannot summon TARDIS at this tim.");
+        add(ModMessages.LANDING_PAD_TRANSIENT, "Cannot summon TARDIS at this time.");
         add(ModMessages.REFUEL, "Enabled refuelling");
         add(ModMessages.STOP_REFUEL, "Stopped refuelling");
         add(ModMessages.NO_DESKTOP_NO_FUEL, "Not enough fuel to start the reconfiguration process");

--- a/forge/src/main/java/whocraft/tardis_refined/neoforge/ClientForgeBus.java
+++ b/forge/src/main/java/whocraft/tardis_refined/neoforge/ClientForgeBus.java
@@ -9,6 +9,7 @@ import net.neoforged.neoforge.event.TickEvent;
 import whocraft.tardis_refined.TardisRefined;
 import whocraft.tardis_refined.client.GravityOverlay;
 import whocraft.tardis_refined.client.TardisClientData;
+import whocraft.tardis_refined.client.TardisClientLogic;
 
 @Mod.EventBusSubscriber(modid = TardisRefined.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
 public class ClientForgeBus {
@@ -19,7 +20,7 @@ public class ClientForgeBus {
             return;
         }
 
-        TardisClientData.tickClientData(Minecraft.getInstance());
+        TardisClientLogic.tickClientData(Minecraft.getInstance());
     }
 
     @SubscribeEvent


### PR DESCRIPTION
We are still releasing with TardisClientData and that sucks because it's a terrible solution for having a ServerLevels Capability on the client. This leads to a issue where we have become complacent and started adding logic to the TardisClientData class which invokes crashes on servers as we have SoundInstances and LocalPlayer references which is too much for a @Enviroment annotation to take

This PR is in a rough state due to writing it to getting a server going but it will be fixed before merge 