### PR TITLE
Immersive Portals - Client crash fix

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/common/crafting/astral_manipulator/ManipulatorCraftingRecipe.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/crafting/astral_manipulator/ManipulatorCraftingRecipe.java
@@ -127,6 +127,14 @@ public class ManipulatorCraftingRecipe implements CraftingRecipe {
 
     @Override
     public ItemStack getResultItem(RegistryAccess registryAccess) {
+        if(result.type() instanceof ManipulatorItemResult manipulatorItemResult){
+            return manipulatorItemResult.recipeOutput();
+        }
+
+        if(result.type() instanceof ManipulatorBlockResult manipulatorBlockResult){
+            return new ItemStack(manipulatorBlockResult.recipeOutput().getBlock().asItem());
+        }
+
         return ItemStack.EMPTY;
     }
     /** Required to allow vanilla to parse the recipe during datapack parsing*/

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/BOTIPortalEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/BOTIPortalEntity.java
@@ -4,6 +4,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
 import qouteall.imm_ptl.core.portal.Portal;
@@ -65,14 +66,21 @@ public class BOTIPortalEntity extends Portal {
     @Override
     public boolean isPortalValid() {
         UUID tardisId = getTardisId();
-        PortalEntry portalEntry = ImmersivePortals.getPortalsForTardis(tardisId);
 
-       /* if(portalEntry == null){
-            return false;
-        }*/
+        if (level() instanceof ServerLevel serverLevel && tickCount > (20 * 40)) {
+            PortalEntry portalEntry = ImmersivePortals.getPortalsForTardis(tardisId);
 
-        if(!isValid){
-            return false;
+            if (portalEntry == null && this.tickCount > (2 * 20) && !this.getOriginWorld().isClientSide()) {
+                return false;
+            }
+
+            if (portalEntry.isPortalValidForEntry(this)) {
+                return true;
+            }
+
+            if (!isValid) {
+                return false;
+            }
         }
 
         return super.isPortalValid();

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/BOTIPortalEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/BOTIPortalEntity.java
@@ -67,9 +67,9 @@ public class BOTIPortalEntity extends Portal {
         UUID tardisId = getTardisId();
         PortalEntry portalEntry = ImmersivePortals.getPortalsForTardis(tardisId);
 
-       /* if(portalEntry == null){
+        if(portalEntry == null && this.tickCount > (2 * 20) && !this.getOriginWorld().isClientSide()){
             return false;
-        }*/
+        }
 
         if(!isValid){
             return false;

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/BOTIPortalEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/BOTIPortalEntity.java
@@ -20,6 +20,7 @@ public class BOTIPortalEntity extends Portal {
 
     // We don't save this as the portals die on server stop, we just need it in RAM
     ShellTheme shellTheme = ShellTheme.FACTORY.get();
+    private boolean isValid = false;
 
     public ShellTheme getShellTheme() {
         return shellTheme;
@@ -40,6 +41,7 @@ public class BOTIPortalEntity extends Portal {
         if (tardisId != null) {
             compoundTag.putUUID(NbtConstants.TARDIS_ID, tardisId);
         }
+        compoundTag.putBoolean("valid", isValid);
     }
 
     @Override
@@ -48,19 +50,38 @@ public class BOTIPortalEntity extends Portal {
         if (compoundTag.contains(NbtConstants.TARDIS_ID)) {
             setTardisId(compoundTag.getUUID(NbtConstants.TARDIS_ID));
         }
+        if(compoundTag.contains("valid")) {
+            setValid(compoundTag.getBoolean("valid"));
+        } else {
+            isValid = false;
+        }
     }
 
     @Override
     public void tick() {
-        UUID tardisId = getTardisId();
-        contemplateExistence(tardisId);
         super.tick();
+    }
+
+    @Override
+    public boolean isPortalValid() {
+        UUID tardisId = getTardisId();
+        PortalEntry portalEntry = ImmersivePortals.getPortalsForTardis(tardisId);
+
+       /* if(portalEntry == null){
+            return false;
+        }*/
+
+        if(!isValid){
+            return false;
+        }
+
+        return super.isPortalValid();
     }
 
     private void contemplateExistence(UUID tardisUuid) {
         PortalEntry portalEntry = ImmersivePortals.getPortalsForTardis(tardisUuid);
         if(portalEntry == null) return;
-        if(!portalEntry.isPortalValidForEntry(this)){
+        if(portalEntry.isPortalValidForEntry(this)){
             kill();
         }
     }
@@ -79,4 +100,11 @@ public class BOTIPortalEntity extends Portal {
         this.getEntityData().set(TARDIS_ID, Optional.of(tardisId));
     }
 
+    public boolean isValid() {
+        return isValid;
+    }
+
+    public void setValid(boolean valid) {
+        isValid = valid;
+    }
 }

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/BOTIPortalEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/BOTIPortalEntity.java
@@ -82,14 +82,6 @@ public class BOTIPortalEntity extends Portal {
         return super.isPortalValid();
     }
 
-    private void contemplateExistence(UUID tardisUuid) {
-        PortalEntry portalEntry = ImmersivePortals.getPortalsForTardis(tardisUuid);
-        if(portalEntry == null) return;
-        if(portalEntry.isPortalValidForEntry(this)){
-            kill();
-        }
-    }
-
     @Override
     protected void defineSynchedData() {
         super.defineSynchedData();
@@ -104,6 +96,8 @@ public class BOTIPortalEntity extends Portal {
         this.getEntityData().set(TARDIS_ID, Optional.of(tardisId));
     }
 
+
+    /*Marks whether or not a portal can live! If set to false the portal will immediately poof out of existence*/
     public boolean isValid() {
         return isValid;
     }

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
@@ -325,6 +325,8 @@ public class ImmersivePortals {
         PortalManipulation.adjustRotationToConnect(exteriorPortal, interiorPortal);
         exteriorPortal.setInteractable(false);
         interiorPortal.setInteractable(false);
+        interiorPortal.setValid(true);
+        exteriorPortal.setValid(true);
 
         CompoundTag tag = new CompoundTag();
         tag.putBoolean("adjustPositionAfterTeleport", false);
@@ -351,8 +353,13 @@ public class ImmersivePortals {
         if (portalEntry == null) {
             return;
         }
+
+        portalEntry.getInternalPortal().setValid(false);
         portalEntry.getInternalPortal().kill();
+
+        portalEntry.getShellPortal().setValid(false);
         portalEntry.getShellPortal().kill();
+
         EXISTING_PORTALS.remove(tardisID);
     }
 
@@ -401,6 +408,8 @@ public class ImmersivePortals {
 
     public static void onServerStopping(MinecraftServer server) {
         EXISTING_PORTALS.forEach((uuid, portalEntry) -> {
+            portalEntry.getShellPortal().setValid(false);
+            portalEntry.getInternalPortal().setValid(false);
             portalEntry.getShellPortal().kill();
             portalEntry.getInternalPortal().kill();
         });

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
@@ -18,6 +18,7 @@ import net.minecraft.world.level.dimension.LevelStem;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 import qouteall.imm_ptl.core.api.PortalAPI;
+import qouteall.imm_ptl.core.portal.Portal;
 import qouteall.imm_ptl.core.portal.PortalManipulation;
 import qouteall.q_misc_util.MiscHelper;
 import qouteall.q_misc_util.api.DimensionAPI;
@@ -42,6 +43,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 
 import static whocraft.tardis_refined.registry.TREntityRegistry.ENTITY_TYPES;
 import static whocraft.tardis_refined.registry.TREntityRegistry.registerStatic;
@@ -354,6 +356,14 @@ public class ImmersivePortals {
             return;
         }
 
+        PortalManipulation.removeConnectedPortals(portalEntry.getInternalPortal(), portal -> {
+
+        });
+
+        PortalManipulation.removeConnectedPortals(portalEntry.getShellPortal(), portal -> {
+
+        });
+
         portalEntry.getInternalPortal().setValid(false);
         portalEntry.getInternalPortal().kill();
 
@@ -367,7 +377,7 @@ public class ImmersivePortals {
         Level world = portal.getDestinationWorld();
 
         BOTIPortalEntity newPortal = entityType.create(world);
-        portal.setTardisId(UUID.fromString(world.dimension().location().getPath()));
+        newPortal.setTardisId(UUID.fromString(world.dimension().location().getPath()));
         newPortal.dimensionTo = portal.level().dimension();
         newPortal.setPos(doorPos);
         newPortal.setDestination(portal.getOriginPos());

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
@@ -367,7 +367,7 @@ public class ImmersivePortals {
         Level world = portal.getDestinationWorld();
 
         BOTIPortalEntity newPortal = entityType.create(world);
-        portal.setTardisId(UUID.fromString(world.dimension().location().getPath()));
+        newPortal.setTardisId(UUID.fromString(world.dimension().location().getPath()));
         newPortal.dimensionTo = portal.level().dimension();
         newPortal.setPos(doorPos);
         newPortal.setDestination(portal.getOriginPos());

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortalsClient.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortalsClient.java
@@ -9,6 +9,7 @@ public class ImmersivePortalsClient {
 
     @Environment(EnvType.CLIENT)
     public static void doClientRenderers() {
+        if(ImmersivePortals.BOTI_PORTAL == null) return;
         EntityRendererRegistry.register(ImmersivePortals.BOTI_PORTAL.get(), BotiPortalRenderer::new);
     }
 

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/PortalEntry.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/PortalEntry.java
@@ -34,8 +34,7 @@ public class PortalEntry {
     }
 
     public boolean isPortalValidForEntry(BOTIPortalEntity portalEntity){
-      //  return portalEntity == internalPortal || portalEntity == shellPortal;
-        return true;
+        return portalEntity.getUUID() != internalPortal.getUUID() && portalEntity.getUUID() != shellPortal.getUUID();
     }
 
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -126,9 +126,9 @@ dependencies {
 
     // Immersive Portals Start
 
-    modCompileOnlyApi ("com.github.iPortalTeam.ImmersivePortalsMod:imm_ptl_core:${rootProject.immersive_portals_version}")
-    modCompileOnlyApi ("com.github.iPortalTeam.ImmersivePortalsMod:q_misc_util:${rootProject.immersive_portals_version}")
-    modCompileOnlyApi ("com.github.iPortalTeam.ImmersivePortalsMod:build:${rootProject.immersive_portals_version}")
+    modImplementation ("com.github.iPortalTeam.ImmersivePortalsMod:imm_ptl_core:${rootProject.immersive_portals_version}")
+    modImplementation ("com.github.iPortalTeam.ImmersivePortalsMod:q_misc_util:${rootProject.immersive_portals_version}")
+    modImplementation ("com.github.iPortalTeam.ImmersivePortalsMod:build:${rootProject.immersive_portals_version}")
 
     /*  // If working on Immersive Portals, change modCompileOnlyApi to modImplementation for the following two entries, this will enable Immersive Portals in Dev
       modCompileOnlyApi("com.github.iPortalTeam.ImmersivePortalsMod:imm_ptl_core:${rootProject.immersive_portals_version}") {

--- a/fabric/src/main/java/whocraft/tardis_refined/fabric/TardisRefinedFabric.java
+++ b/fabric/src/main/java/whocraft/tardis_refined/fabric/TardisRefinedFabric.java
@@ -79,8 +79,8 @@ public class TardisRefinedFabric implements ModInitializer {
 
         if (ModCompatChecker.immersivePortals()) {
             if (TRConfig.COMMON.COMPATIBILITY_IP.get()) {
-            ImmersivePortals.init();
-            PortalsCompatFabric.init();
+                ImmersivePortals.init();
+                PortalsCompatFabric.init();
             }
         } else {
             TardisRefined.LOGGER.info("ImmersivePortals was not detected.");


### PR DESCRIPTION
Fixes a issue where the game tries to attach a renderer to a entity that doesn't exist