### PR TITLE
More consistency in networking

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/common/network/MessageS2C.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/network/MessageS2C.java
@@ -16,6 +16,10 @@ public abstract class MessageS2C extends Message {
         this.getType().getNetworkManager().sendToPlayer(player, this);
     }
 
+    public void sendToTrackingAndSelf(ServerPlayer player) {
+        this.getType().getNetworkManager().sendToTrackingAndSelf(player, this);
+    }
+
     public void sendToDimension(Level level) {
         this.getType().getNetworkManager().sendToDimension(level, this);
     }

--- a/common/src/main/java/whocraft/tardis_refined/common/network/NetworkManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/network/NetworkManager.java
@@ -47,6 +47,8 @@ public abstract class NetworkManager {
 
     public abstract void sendToPlayer(ServerPlayer player, MessageS2C message);
 
+    public abstract void sendToTrackingAndSelf(ServerPlayer player, MessageS2C message);
+
     public abstract void sendToTracking(Entity entity, MessageS2C message);
 
     public abstract void sendToTracking(BlockEntity entity, MessageS2C message);

--- a/fabric/src/main/java/whocraft/tardis_refined/common/network/fabric/NetworkManagerImpl.java
+++ b/fabric/src/main/java/whocraft/tardis_refined/common/network/fabric/NetworkManagerImpl.java
@@ -87,6 +87,12 @@ public class NetworkManagerImpl extends NetworkManager {
     }
 
     @Override
+    public void sendToTrackingAndSelf(ServerPlayer player, MessageS2C message) {
+        this.sendToTracking(player, message);
+        this.sendToPlayer(player, message);
+    }
+
+    @Override
     public void sendToTracking(Entity entity, MessageS2C message) {
         PlayerLookup.tracking(entity).stream().forEach(player -> {
             this.sendToPlayer(player, message);

--- a/forge/src/main/java/whocraft/tardis_refined/common/network/neoforge/NetworkManagerImpl.java
+++ b/forge/src/main/java/whocraft/tardis_refined/common/network/neoforge/NetworkManagerImpl.java
@@ -54,12 +54,21 @@ public class NetworkManagerImpl extends NetworkManager {
     }
 
     @Override
+    public void sendToTrackingAndSelf(ServerPlayer player, MessageS2C message) {
+        if (!this.toClient.containsValue(message.getType())) {
+            TardisRefined.LOGGER.error("Message type not registered: " + message.getType().getId());
+            return;
+        }
+        this.channel.send(PacketDistributor.TRACKING_ENTITY_AND_SELF.with(() -> player), message);
+    }
+
+    @Override
     public void sendToTracking(Entity entity, MessageS2C message) {
         if (!this.toClient.containsValue(message.getType())) {
             TardisRefined.LOGGER.error("Message type not registered: " + message.getType().getId());
             return;
         }
-        this.channel.send(PacketDistributor.TRACKING_ENTITY_AND_SELF.with(() -> entity), message);
+        this.channel.send(PacketDistributor.TRACKING_ENTITY.with(() -> entity), message);
     }
 
     @Override


### PR DESCRIPTION
Currently the Fabric implementation of NetworkManager, when sending packets to players tracking an entity, will not send the packet to the entity if it is a player, whilst the Neo/Forge implementation will. This is a small PR to add another method so that there is more consistency between platforms. I know Refined doesn't use either method, but it is useful for addon mods