### PR TITLE
Suggested Feature: Upgradable Flight Speed

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/common/capability/upgrades/SpeedUpgrade.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/capability/upgrades/SpeedUpgrade.java
@@ -1,0 +1,27 @@
+package whocraft.tardis_refined.common.capability.upgrades;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.function.Supplier;
+
+public class SpeedUpgrade extends Upgrade {
+    private int speedModifier = 1;
+
+    public SpeedUpgrade(Supplier<ItemStack> icon, ResourceLocation translationKey, UpgradeType upgradeType) {
+        super(icon, translationKey, upgradeType);
+    }
+
+    public SpeedUpgrade(Supplier<ItemStack> icon, Supplier<Upgrade> parent, ResourceLocation translationKey, UpgradeType upgradeType) {
+        super(icon, parent, translationKey, upgradeType);
+    }
+
+    public int getSpeedModifier() {
+        return speedModifier;
+    }
+
+    public SpeedUpgrade setSpeedModifier(int speedModifier) {
+        this.speedModifier = speedModifier;
+        return this;
+    }
+}

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -24,6 +24,7 @@ import whocraft.tardis_refined.common.block.console.GlobalConsoleBlock;
 import whocraft.tardis_refined.common.blockentity.console.GlobalConsoleBlockEntity;
 import whocraft.tardis_refined.common.capability.TardisLevelOperator;
 import whocraft.tardis_refined.common.capability.upgrades.IncrementUpgrade;
+import whocraft.tardis_refined.common.capability.upgrades.SpeedUpgrade;
 import whocraft.tardis_refined.common.capability.upgrades.Upgrade;
 import whocraft.tardis_refined.common.capability.upgrades.UpgradeHandler;
 import whocraft.tardis_refined.registry.TRUpgrades;
@@ -67,6 +68,7 @@ public class TardisPilotingManager extends BaseHandler {
 
     private boolean isCrashing = false;
 
+    private int speedModifier = 1;
 
     private boolean canUseControls = true;
 
@@ -114,7 +116,7 @@ public class TardisPilotingManager extends BaseHandler {
         this.ticksCrashing = tag.getInt("ticksCrashing");
         this.ticksSinceCrash = tag.getInt("ticksSinceCrash");
         this.flightDistance = tag.getInt(NbtConstants.FLIGHT_DISTANCE);
-        this.distanceCovered = tag.getInt(NbtConstants.FLIGHT_DISTANCE);
+        this.distanceCovered = tag.getInt(NbtConstants.DISTANCE_COVERED);
         this.canUseControls = tag.getBoolean("canUseControls");
 
         if (this.targetLocation == null) {
@@ -122,6 +124,7 @@ public class TardisPilotingManager extends BaseHandler {
         }
 
         this.cordIncrementIndex = tag.getInt(NbtConstants.CONTROL_INCREMENT_INDEX);
+        this.speedModifier = tag.getInt(NbtConstants.SPEED_MODIFIER);
 
         this.fuel = tag.getDouble(NbtConstants.FUEL);
         this.maximumFuel = tag.getDouble(NbtConstants.MAXIMUM_FUEL);
@@ -142,6 +145,7 @@ public class TardisPilotingManager extends BaseHandler {
         tag.putBoolean(NbtConstants.CONTROL_AUTOLAND, this.autoLand);
         tag.putBoolean(NbtConstants.IS_HANDBRAKE_ON, this.isHandbrakeOn);
         tag.putInt(NbtConstants.THROTTLE_STAGE, this.throttleStage);
+        tag.putInt(NbtConstants.SPEED_MODIFIER, this.speedModifier);
 
         tag.putInt("ticksCrashing", this.ticksCrashing);
         tag.putInt("ticksSinceCrash", this.ticksSinceCrash);
@@ -229,7 +233,7 @@ public class TardisPilotingManager extends BaseHandler {
 
             if (this.operator.getLevel().getGameTime() % (20) == 0) {
                 if (distanceCovered <= flightDistance) {
-                    distanceCovered += throttleStage + (0.5 * throttleStage);
+                    distanceCovered += (int) (throttleStage + (0.5 * throttleStage * speedModifier));
 
                     // If this tick was enough to push us over.
                     if (distanceCovered >= flightDistance) {
@@ -472,16 +476,13 @@ public class TardisPilotingManager extends BaseHandler {
             this.isPassivelyRefuelling = false;
             this.flightDistance = 0;
             this.distanceCovered = 0;
-
-
+            this.speedModifier = this.getLatestSpeedModifier();
 
             this.fastReturnLocation = new TardisNavLocation(this.getCurrentLocation().getPosition(), this.getCurrentLocation().getDirection(), this.getCurrentLocation().getLevel());
 
 
             TardisNavLocation targetPosition = this.operator.getPilotingManager().getTargetLocation();
-            TardisNavLocation lastKnownLocation = new TardisNavLocation(this.getCurrentLocation().getPosition(), this.getCurrentLocation().getDirection(), this.getCurrentLocation().getLevel());
-
-            // Do we not have a last known location?
+            TardisNavLocation lastKnownLocation = this.fastReturnLocation;
 
             this.flightDistance = calculateFlightDistance(lastKnownLocation, targetPosition);
 
@@ -1037,5 +1038,25 @@ public class TardisPilotingManager extends BaseHandler {
 
         // Temporary sfx
         this.operator.getLevel().playSound(null, TardisArchitectureHandler.DESKTOP_CENTER_POS, SoundEvents.BEACON_ACTIVATE, SoundSource.BLOCKS, 1000f, 0.6f);
+    }
+
+    /**
+     * Returns the speed modifier as determined by which speed upgrades
+     * are unlocked.
+     */
+    private int getLatestSpeedModifier() {
+        UpgradeHandler upgradeHandler = this.operator.getUpgradeHandler();
+        Upgrade upgrade = TRUpgrades.SPEED_III.get();
+
+        while (upgrade instanceof SpeedUpgrade)
+        {
+            if (upgradeHandler.isUpgradeUnlocked(upgrade)) {
+                return ((SpeedUpgrade) upgrade).getSpeedModifier();
+            }
+
+            upgrade = upgrade.getParent();
+        }
+
+        return this.speedModifier;
     }
 }

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -1048,11 +1048,13 @@ public class TardisPilotingManager extends BaseHandler {
         UpgradeHandler upgradeHandler = this.operator.getUpgradeHandler();
         Upgrade upgrade = TRUpgrades.SPEED_III.get();
 
-        while (upgrade instanceof SpeedUpgrade)
+        for (int i = 0; i < 3; i++)
         {
-            if (upgradeHandler.isUpgradeUnlocked(upgrade)) {
+            if (!(upgrade instanceof SpeedUpgrade))
+                return this.speedModifier;
+
+            if (upgradeHandler.isUpgradeUnlocked(upgrade))
                 return ((SpeedUpgrade) upgrade).getSpeedModifier();
-            }
 
             upgrade = upgrade.getParent();
         }

--- a/common/src/main/java/whocraft/tardis_refined/constants/NbtConstants.java
+++ b/common/src/main/java/whocraft/tardis_refined/constants/NbtConstants.java
@@ -79,6 +79,7 @@ public class NbtConstants {
     // Flight
     public static final String FLIGHT_DISTANCE = "flight_distance";
     public static final String DISTANCE_COVERED = "distance_covered";
+    public static final String SPEED_MODIFIER = "speed_modifier";
 
 
     // Piloting Manager

--- a/common/src/main/java/whocraft/tardis_refined/registry/TRUpgrades.java
+++ b/common/src/main/java/whocraft/tardis_refined/registry/TRUpgrades.java
@@ -7,6 +7,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
 import whocraft.tardis_refined.TardisRefined;
 import whocraft.tardis_refined.common.capability.upgrades.IncrementUpgrade;
+import whocraft.tardis_refined.common.capability.upgrades.SpeedUpgrade;
 import whocraft.tardis_refined.common.capability.upgrades.Upgrade;
 import whocraft.tardis_refined.common.util.RegistryHelper;
 
@@ -70,6 +71,16 @@ public class TRUpgrades {
     public static final RegistrySupplier<Upgrade> LANDING_PAD = UPGRADE_DEFERRED_REGISTRY.register("landing_pad", () -> new Upgrade(TRBlockRegistry.LANDING_PAD.get().asItem()::getDefaultInstance, NAVIGATION_SYSTEM, RegistryHelper.makeKey("landing_pad"), Upgrade.UpgradeType.SUB_UPGRADE)
             .setSkillPointsRequired(10).setPosition(8, 2));
 
+    // Flight Upgrades
+    public static final RegistrySupplier<Upgrade> FLIGHT_SYSTEM = UPGRADE_DEFERRED_REGISTRY.register("flight_system", () -> new Upgrade(Items.ELYTRA::getDefaultInstance, TARDIS_XP, RegistryHelper.makeKey("flight_system"), Upgrade.UpgradeType.MAIN_UPGRADE)
+            .setSkillPointsRequired(1).setPosition(9, 1));
 
+    public static final RegistrySupplier<Upgrade> SPEED_I = UPGRADE_DEFERRED_REGISTRY.register("speed_i", () -> new SpeedUpgrade(Items.FIREWORK_ROCKET::getDefaultInstance, FLIGHT_SYSTEM, RegistryHelper.makeKey("speed_i"), Upgrade.UpgradeType.SUB_UPGRADE).setSpeedModifier(2)
+            .setSkillPointsRequired(10).setPosition(9, 2));
 
+    public static final RegistrySupplier<Upgrade> SPEED_II = UPGRADE_DEFERRED_REGISTRY.register("speed_ii", () -> new SpeedUpgrade(Items.FIREWORK_ROCKET::getDefaultInstance, SPEED_I, RegistryHelper.makeKey("speed_ii"), Upgrade.UpgradeType.SUB_UPGRADE).setSpeedModifier(5)
+            .setSkillPointsRequired(20).setPosition(9, 3));
+
+    public static final RegistrySupplier<Upgrade> SPEED_III = UPGRADE_DEFERRED_REGISTRY.register("speed_iii", () -> new SpeedUpgrade(Items.FIREWORK_ROCKET::getDefaultInstance, SPEED_II, RegistryHelper.makeKey("speed_iii"), Upgrade.UpgradeType.SUB_UPGRADE).setSpeedModifier(10)
+            .setSkillPointsRequired(30).setPosition(9, 4));
 }

--- a/forge/src/main/java/whocraft/tardis_refined/common/data/LangProviderEnglish.java
+++ b/forge/src/main/java/whocraft/tardis_refined/common/data/LangProviderEnglish.java
@@ -271,7 +271,10 @@ public class LangProviderEnglish extends LanguageProvider {
         addUpgrade(TRUpgrades.IMPROVED_GENERATION_TIME_I.get(), "Improved Generation I", "Lowers desktop wait times to 120 seconds");
         addUpgrade(TRUpgrades.IMPROVED_GENERATION_TIME_II.get(), "Improved Generation II", "Lowers desktop wait times to 60 seconds");
         addUpgrade(TRUpgrades.IMPROVED_GENERATION_TIME_III.get(), "Improved Generation III", "Lowers desktop wait times to 10 seconds");
-
+        addUpgrade(TRUpgrades.FLIGHT_SYSTEM.get(), "Flight System", "Allows upgrades to the TARDIS Flight System");
+        addUpgrade(TRUpgrades.SPEED_I.get(), "Speed I", "Flight speed is 2x faster");
+        addUpgrade(TRUpgrades.SPEED_II.get(), "Speed II", "Flight speed is 5x faster");
+        addUpgrade(TRUpgrades.SPEED_III.get(), "Speed III", "Flight speed is 10x faster");
 
     }
 

--- a/lang/en_us.json
+++ b/lang/en_us.json
@@ -207,13 +207,5 @@
   "upgrade.tardis_refined.tardis_xp": "System Upgrades",
   "upgrade.tardis_refined.tardis_xp.description": "Allows upgrades to the TARDIS",
   "upgrade.tardis_refined.waypoints": "Waypoints",
-  "upgrade.tardis_refined.waypoints.description": "Allows the Pilot to create saved locations",
-  "upgrade.tardis_refined.flight_system": "Flight System",
-  "upgrade.tardis_refined.flight_system.description": "Allows upgrades to the TARDIS Flight System",
-  "upgrade.tardis_refined.speed_i": "Speed I",
-  "upgrade.tardis_refined.speed_i.description": "Flight speed is 2x faster",
-  "upgrade.tardis_refined.speed_ii": "Speed II",
-  "upgrade.tardis_refined.speed_ii.description": "Flight speed is 5x faster",
-  "upgrade.tardis_refined.speed_iii": "Speed III",
-  "upgrade.tardis_refined.speed_iii.description": "Flight speed is 10x faster"
+  "upgrade.tardis_refined.waypoints.description": "Allows the Pilot to create saved locations"
 }

--- a/lang/en_us.json
+++ b/lang/en_us.json
@@ -207,5 +207,13 @@
   "upgrade.tardis_refined.tardis_xp": "System Upgrades",
   "upgrade.tardis_refined.tardis_xp.description": "Allows upgrades to the TARDIS",
   "upgrade.tardis_refined.waypoints": "Waypoints",
-  "upgrade.tardis_refined.waypoints.description": "Allows the Pilot to create saved locations"
+  "upgrade.tardis_refined.waypoints.description": "Allows the Pilot to create saved locations",
+  "upgrade.tardis_refined.flight_system": "Flight System",
+  "upgrade.tardis_refined.flight_system.description": "Allows upgrades to the TARDIS Flight System",
+  "upgrade.tardis_refined.speed_i": "Speed I",
+  "upgrade.tardis_refined.speed_i.description": "Flight speed is 2x faster",
+  "upgrade.tardis_refined.speed_ii": "Speed II",
+  "upgrade.tardis_refined.speed_ii.description": "Flight speed is 5x faster",
+  "upgrade.tardis_refined.speed_iii": "Speed III",
+  "upgrade.tardis_refined.speed_iii.description": "Flight speed is 10x faster"
 }


### PR DESCRIPTION
Something like this (or better) might already be in the works, couldn't see anything related to it here - so if it isn't, then here is my suggestion to extend the upgrade tree to include a "Flight System" category (which right now are just 3 tiers of speed upgrades, but I could see this category being used for future features too).

Speed tiers & their costs:
| Title  | Description | Points |
| ------------- | ------------- | - |
| Flight System  | Unlocks category | 1 |
| Speed I  | 2x flight speed | 10 |
| Speed II  | 5x flight speed | 20 |
| Speed III  | 10x flight speed | 30 |

Right now it's an up to 10x multiplier on the distance travelled per tick, which could be a little too op, this could be balanced by either reducing the multiplier's or consuming more fuel. Additionally, since points would be easier to get, the rest of the upgrade tree might need their points balanced.