### PR TITLE
Fix fabric ConcurrentModificationException on cutting shell after #362

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/RootedShellBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/RootedShellBlockEntity.java
@@ -25,6 +25,7 @@ public class RootedShellBlockEntity extends ShellBaseBlockEntity{
     }
 
     private boolean runSetUpOnNextTick = false;
+    public static boolean setUpOnNextTick = false; // used in fabric MinecraftServer:getAllLevels mixin
 
     @Override
     public DesktopTheme getAssociatedTheme() {
@@ -50,7 +51,8 @@ public class RootedShellBlockEntity extends ShellBaseBlockEntity{
     }
 
     public void setUpTardisOnNextTick() {
-        runSetUpOnNextTick = true;
+        this.runSetUpOnNextTick = true;
+        setUpOnNextTick = true;
     }
 
     /** Generate the dimension and open the Root Shell */

--- a/fabric/src/main/java/whocraft/tardis_refined/mixin/fabric/MinecraftServerMixin.java
+++ b/fabric/src/main/java/whocraft/tardis_refined/mixin/fabric/MinecraftServerMixin.java
@@ -1,0 +1,23 @@
+package whocraft.tardis_refined.mixin.fabric;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import org.apache.commons.compress.utils.Lists;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import whocraft.tardis_refined.common.blockentity.shell.RootedShellBlockEntity;
+
+
+@Mixin(MinecraftServer.class)
+public class MinecraftServerMixin {
+    @ModifyExpressionValue(method = "tickChildren(Ljava/util/function/BooleanSupplier;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;getAllLevels()Ljava/lang/Iterable;"))
+    public Iterable<ServerLevel> getAllLevels(Iterable<ServerLevel> original) {
+        if (RootedShellBlockEntity.setUpOnNextTick) {
+            // if we are going to modify the levels map in this tick, make sure we iterate over a copy of it instead.
+            RootedShellBlockEntity.setUpOnNextTick = false;
+            return Lists.newArrayList(original.iterator());
+        }
+        return original;
+    }
+}

--- a/fabric/src/main/resources/tardis_refined.mixins.json
+++ b/fabric/src/main/resources/tardis_refined.mixins.json
@@ -4,7 +4,8 @@
   "package": "whocraft.tardis_refined.mixin.fabric",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "BlockItemMixin"
+    "BlockItemMixin",
+    "MinecraftServerMixin"
   ],
   "client": [
   ],

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ enabled_platforms=neoforge,fabric
 architectury_version=8.1.79
 
 #Fabric
-fabric_loader_version=0.14.24
+fabric_loader_version=0.15.6
 fabric_api_version=0.87.0+1.20.2
 fabric_api_version_range=>=0.87.0+1.20.2
 fabric_loader_version_range=>=0.7.4


### PR DESCRIPTION
It looks like I accidentally introduced a bug with #362 in the fabric version of this mod (which I didn't test), sorry about that.
A ConcurrentModificationException occurs when shearing open a rooted shell.
Forge apparently includes a patch that fixes this exact issue, but fabric doesn't.

I've fixed it with a small mixin.