### PR TITLE
Valkyrien Skies integration

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     }
 
     modCompileOnly("com.simibubi.create:create-fabric-${minecraft_version}:${create_version_fabric}")
+    modCompileOnly("maven.modrinth:valkyrien-skies:${minecraft_version}-fabric-${valkyrienskies_version}")
 
 }
 

--- a/common/src/main/java/whocraft/tardis_refined/client/ScreenHandler.java
+++ b/common/src/main/java/whocraft/tardis_refined/client/ScreenHandler.java
@@ -42,13 +42,13 @@ public class ScreenHandler {
     }
 
     @Environment(EnvType.CLIENT)
-    public static void openMonitorScreen(boolean desktopGenerating, CompoundTag upgradeHandlerNbt, TardisNavLocation currentLocation, TardisNavLocation targetLocation) {
+    public static void openMonitorScreen(boolean desktopGenerating, CompoundTag upgradeHandlerNbt, TardisNavLocation currentLocation, TardisNavLocation targetLocation, ResourceKey<Level> tardisId) {
         if (desktopGenerating) {
             Minecraft.getInstance().setScreen(new CancelDesktopScreen());
         } else {
             UpgradeHandler upgradeHandlerClient = new UpgradeHandler(new TardisLevelOperator(Minecraft.getInstance().level));
             upgradeHandlerClient.loadData(upgradeHandlerNbt);
-            Minecraft.getInstance().setScreen(new MonitorScreen(currentLocation, targetLocation, upgradeHandlerClient));
+            Minecraft.getInstance().setScreen(new MonitorScreen(currentLocation, targetLocation, upgradeHandlerClient, tardisId));
         }
     }
 

--- a/common/src/main/java/whocraft/tardis_refined/client/screen/MonitorScreen.java
+++ b/common/src/main/java/whocraft/tardis_refined/client/screen/MonitorScreen.java
@@ -6,7 +6,9 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
 import whocraft.tardis_refined.TardisRefined;
 import whocraft.tardis_refined.client.screen.components.GenericMonitorSelectionList;
 import whocraft.tardis_refined.client.screen.components.SelectionListEntry;
@@ -15,7 +17,9 @@ import whocraft.tardis_refined.client.screen.selections.HumSelectionScreen;
 import whocraft.tardis_refined.client.screen.selections.SelectionScreen;
 import whocraft.tardis_refined.common.capability.upgrades.UpgradeHandler;
 import whocraft.tardis_refined.common.network.messages.EjectPlayerFromConsoleMessage;
+import whocraft.tardis_refined.common.network.messages.screens.C2SMonitorClosed;
 import whocraft.tardis_refined.common.network.messages.screens.C2SRequestShellSelection;
+import whocraft.tardis_refined.common.network.messages.screens.MonitorPositionDataMessage;
 import whocraft.tardis_refined.common.network.messages.waypoints.RequestWaypointsMessage;
 import whocraft.tardis_refined.common.tardis.TardisNavLocation;
 import whocraft.tardis_refined.common.util.MiscHelper;
@@ -28,20 +32,27 @@ import java.awt.*;
 public class MonitorScreen extends SelectionScreen {
 
     public static ResourceLocation MONITOR_TEXTURE = new ResourceLocation(TardisRefined.MODID, "textures/gui/monitor.png");
-    private final TardisNavLocation currentLocation;
     private final TardisNavLocation targetLocation;
     private final UpgradeHandler upgradeHandler;
     protected int imageWidth = 256;
     protected int imageHeight = 173;
     private int leftPos, topPos;
     private boolean noUpgrades = false;
+    private ResourceKey<Level> tardisId;
 
 
-    public MonitorScreen(TardisNavLocation currentLocation, TardisNavLocation targetLocation, UpgradeHandler upgradeHandler) {
+    public MonitorScreen(TardisNavLocation currentLocation, TardisNavLocation targetLocation, UpgradeHandler upgradeHandler, ResourceKey<Level> tardisId) {
         super(Component.translatable(ModMessages.UI_MONITOR_MAIN_TITLE));
-        this.currentLocation = currentLocation;
         this.targetLocation = targetLocation;
         this.upgradeHandler = upgradeHandler;
+        this.tardisId = tardisId;
+        MonitorPositionDataMessage.lastLocation = currentLocation;
+    }
+
+    @Override
+    public void onClose() {
+        super.onClose();
+        new C2SMonitorClosed(this.tardisId).send();
     }
 
     @Override
@@ -92,6 +103,7 @@ public class MonitorScreen extends SelectionScreen {
     @Override
     public void render(GuiGraphics guiGraphics, int i, int j, float f) {
         super.render(guiGraphics, i, j, f);
+        TardisNavLocation currentLocation = MonitorPositionDataMessage.lastLocation;
         int textOffset = height / 2 - 35;
 
         int upgradesLeftPos = this.width / 2 - 75;

--- a/common/src/main/java/whocraft/tardis_refined/common/block/device/LandingPad.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/block/device/LandingPad.java
@@ -82,11 +82,16 @@ public class LandingPad extends Block {
                             TardisPilotingManager pilotManager = operator.getPilotingManager();
                             UpgradeHandler upgradeHandler = operator.getUpgradeHandler();
 
-                            if (TRUpgrades.LANDING_PAD.get().isUnlocked(upgradeHandler) && pilotManager.beginFlight(true, null) && !pilotManager.isOnCooldown()) {
+                            if (TRUpgrades.LANDING_PAD.get().isUnlocked(upgradeHandler) && !pilotManager.isOnCooldown()) {
+                                TardisNavLocation oldTarget = pilotManager.getTargetLocation();
                                 pilotManager.setTargetLocation(new TardisNavLocation(blockPos.above(), player.getDirection().getOpposite(), serverLevel));
-                                serverLevel.playSound(null, blockPos, SoundEvents.PLAYER_LEVELUP, SoundSource.BLOCKS, 1f, 1f);
-                                PlayerUtil.sendMessage(player, Component.translatable(ModMessages.TARDIS_IS_ON_THE_WAY), true);
-                                return InteractionResult.PASS;
+                                if (pilotManager.beginFlight(true, null)) {
+                                    serverLevel.playSound(null, blockPos, SoundEvents.PLAYER_LEVELUP, SoundSource.BLOCKS, 1f, 1f);
+                                    PlayerUtil.sendMessage(player, Component.translatable(ModMessages.TARDIS_IS_ON_THE_WAY), true);
+                                    return InteractionResult.PASS;
+                                } else {
+                                    pilotManager.setTargetLocation(oldTarget);
+                                }
                             } else {
 
                                 if (TRUpgrades.LANDING_PAD.get().isUnlocked(upgradeHandler)) {

--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/door/AbstractDoorBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/door/AbstractDoorBlockEntity.java
@@ -144,9 +144,6 @@ public class AbstractDoorBlockEntity extends BlockEntity implements TardisIntern
     @Override
     public void onAttemptEnter(BlockState blockState, Level level, BlockPos doorPos, Entity entity) {
         if (!entity.level().isClientSide() && level instanceof ServerLevel serverLevel) {
-            if (entity.isOnPortalCooldown()) {
-                return;
-            }
             Optional<TardisLevelOperator> data = TardisLevelOperator.get(serverLevel);
             data.ifPresent(tardisLevelOperator -> {
                 tardisLevelOperator.setInternalDoor(this);

--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/door/AbstractDoorBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/door/AbstractDoorBlockEntity.java
@@ -144,6 +144,9 @@ public class AbstractDoorBlockEntity extends BlockEntity implements TardisIntern
     @Override
     public void onAttemptEnter(BlockState blockState, Level level, BlockPos doorPos, Entity entity) {
         if (!entity.level().isClientSide() && level instanceof ServerLevel serverLevel) {
+            if (entity.isOnPortalCooldown()) {
+                return;
+            }
             Optional<TardisLevelOperator> data = TardisLevelOperator.get(serverLevel);
             data.ifPresent(tardisLevelOperator -> {
                 tardisLevelOperator.setInternalDoor(this);

--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
@@ -47,6 +47,14 @@ public abstract class ShellBaseBlockEntity extends BlockEntity implements Exteri
     private final int DUPLICATION_CHECK_TIME = 1200; // A minute
     public AnimationState liveliness = new AnimationState();
     protected ResourceKey<Level> TARDIS_ID;
+    /*
+        Because we assume it is possible for the tardis to change location without flying there,
+        the 'if (!myCurrentPosition.equals(currentLocation) && !myCurrentPosition.equals(wantedDestination))' block
+        in the duplication check that runs once every so often would mistakenly remove this tardis if it just loaded
+        in the same tick at a different location (if we are unlocky with tick order),
+        because the operator's currentPosition will be set in the tick after.
+        We therefore need a way to skip the duplication check for a single tick when loading in this blockentity.
+     */
     private boolean doNotRemoveNextTick = false;
 
     public ShellBaseBlockEntity(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {

--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
@@ -122,9 +122,6 @@ public abstract class ShellBaseBlockEntity extends BlockEntity implements Exteri
                 TardisRefined.LOGGER.error("Error in onAttemptEnter: null Tardis ID (Invalid block or not terraformed yet?) [" + externalShellPos.toShortString() + "]");
                 return;
             }
-            if (entity.isOnPortalCooldown()) {
-                return;
-            }
             ServerLevel interior = DimensionHandler.getOrCreateInterior(serverLevel, this.TARDIS_ID.location());
             TardisLevelOperator.get(interior).ifPresent(cap -> {
 

--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
@@ -80,11 +80,6 @@ public abstract class ShellBaseBlockEntity extends BlockEntity implements Exteri
 
     @Override
     protected void saveAdditional(CompoundTag pTag) {
-        if (this.TARDIS_ID == null) {
-            TardisRefined.LOGGER.error("Error in saveAdditional: null Tardis ID (Invalid block or not terraformed yet?) [" + this.getBlockPos().toShortString() + "]");
-            return;
-        }
-
         super.saveAdditional(pTag);
         if (this.TARDIS_ID != null)
             pTag.putString(NbtConstants.TARDIS_ID, TARDIS_ID.location().toString());

--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
@@ -109,6 +109,9 @@ public abstract class ShellBaseBlockEntity extends BlockEntity implements Exteri
                 TardisRefined.LOGGER.error("Error in onAttemptEnter: null Tardis ID (Invalid block or not terraformed yet?) [" + externalShellPos.toShortString() + "]");
                 return;
             }
+            if (entity.isOnPortalCooldown()) {
+                return;
+            }
             ServerLevel interior = DimensionHandler.getOrCreateInterior(serverLevel, this.TARDIS_ID.location());
             TardisLevelOperator.get(interior).ifPresent(cap -> {
 

--- a/common/src/main/java/whocraft/tardis_refined/common/capability/TardisLevelOperator.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/capability/TardisLevelOperator.java
@@ -163,24 +163,22 @@ public class TardisLevelOperator{
         if (pilotingManager != null) {  pilotingManager.tick(level);}
         if (flightDanceManager != null) {  flightDanceManager.tick(level);}
 
-        
-        var shouldSync = level.getGameTime() % 40 == 0;
-        if (shouldSync) {
-            tardisClientData.setIsOnCooldown(pilotingManager.isOnCooldown());
-            tardisClientData.setShellTheme(aestheticHandler.getShellTheme());
-            tardisClientData.setShellPattern(aestheticHandler.shellPattern().id());
-            tardisClientData.setHumEntry(interiorManager.getHumEntry());
-            tardisClientData.setFuel(pilotingManager.getFuel());
-            tardisClientData.setMaximumFuel(pilotingManager.getMaximumFuel());
-            tardisClientData.setTardisState(tardisState);
 
-            tardisClientData.sync();
-        } else {
-            tardisClientData.setFlying(pilotingManager.isInFlight());
-            tardisClientData.setIsLanding(exteriorManager.isLanding());
-            tardisClientData.setIsTakingOff(exteriorManager.isTakingOff());
-            tardisClientData.setThrottleStage(pilotingManager.getThrottleStage());
-            tardisClientData.setHandbrakeEngaged(pilotingManager.isHandbrakeOn());
+        CompoundTag oldData = tardisClientData.serializeNBT();
+        tardisClientData.setIsOnCooldown(pilotingManager.isOnCooldown());
+        tardisClientData.setShellTheme(aestheticHandler.getShellTheme());
+        tardisClientData.setShellPattern(aestheticHandler.shellPattern().id());
+        tardisClientData.setHumEntry(interiorManager.getHumEntry());
+        tardisClientData.setFuel(pilotingManager.getFuel());
+        tardisClientData.setMaximumFuel(pilotingManager.getMaximumFuel());
+        tardisClientData.setTardisState(tardisState);
+        tardisClientData.setFlying(pilotingManager.isInFlight());
+        tardisClientData.setIsLanding(exteriorManager.isLanding());
+        tardisClientData.setIsTakingOff(exteriorManager.isTakingOff());
+        tardisClientData.setThrottleStage(pilotingManager.getThrottleStage());
+        tardisClientData.setHandbrakeEngaged(pilotingManager.isHandbrakeOn());
+        CompoundTag newData = tardisClientData.serializeNBT();
+        if (!oldData.equals(newData)) {
             tardisClientData.sync();
         }
     }

--- a/common/src/main/java/whocraft/tardis_refined/common/capability/TardisLevelOperator.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/capability/TardisLevelOperator.java
@@ -208,6 +208,7 @@ public class TardisLevelOperator{
 
             this.pilotingManager.setCurrentLocation(new TardisNavLocation(externalShellPos, shellDirection.getOpposite(), shellLevel));
 
+            entity.setPortalCooldown();
             TardisHelper.teleportEntityTardis(this, entity, sourceLocation, targetLocation, true);
             return true;
         }
@@ -254,6 +255,7 @@ public class TardisLevelOperator{
             TardisNavLocation sourceLocation = new TardisNavLocation(doorPos, doorDirection, doorLevel);
             TardisNavLocation destinationLocation = new TardisNavLocation(teleportPos, targetDirection, targetLevel);
 
+            entity.setPortalCooldown();
             TardisHelper.teleportEntityTardis(this, entity, sourceLocation, destinationLocation, false);
             return true;
         }

--- a/common/src/main/java/whocraft/tardis_refined/common/capability/TardisLevelOperator.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/capability/TardisLevelOperator.java
@@ -43,6 +43,7 @@ import whocraft.tardis_refined.patterns.ShellPatterns;
 import whocraft.tardis_refined.registry.TRBlockRegistry;
 
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -186,9 +187,11 @@ public class TardisLevelOperator{
             tardisClientData.sync();
         }
 
-        for(ServerPlayer player : updatingMonitors) {
+        Iterator<ServerPlayer> updatingMonitorsIterator = updatingMonitors.iterator();
+        while(updatingMonitorsIterator.hasNext()) {
+            ServerPlayer player = updatingMonitorsIterator.next();
             if (player.isRemoved()) {
-                updatingMonitors.remove(player);
+                updatingMonitorsIterator.remove();
                 continue;
             }
 

--- a/common/src/main/java/whocraft/tardis_refined/common/capability/TardisLevelOperator.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/capability/TardisLevelOperator.java
@@ -222,7 +222,6 @@ public class TardisLevelOperator{
             TardisNavLocation targetLocation = new TardisNavLocation(targetPosition, doorDirection, targetServerLevel);
 
 
-            entity.setPortalCooldown();
             TardisHelper.teleportEntityTardis(this, entity, sourceLocation, targetLocation, true);
             return true;
         }
@@ -269,7 +268,6 @@ public class TardisLevelOperator{
             TardisNavLocation sourceLocation = new TardisNavLocation(doorPos, doorDirection, doorLevel);
             TardisNavLocation destinationLocation = new TardisNavLocation(teleportPos, targetDirection, targetLevel);
 
-            entity.setPortalCooldown();
             TardisHelper.teleportEntityTardis(this, entity, sourceLocation, destinationLocation, false);
             return true;
         }

--- a/common/src/main/java/whocraft/tardis_refined/common/network/TardisNetwork.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/network/TardisNetwork.java
@@ -7,9 +7,7 @@ import whocraft.tardis_refined.common.network.messages.ChangeDesktopMessage;
 import whocraft.tardis_refined.common.network.messages.ChangeShellMessage;
 import whocraft.tardis_refined.common.network.messages.EjectPlayerFromConsoleMessage;
 import whocraft.tardis_refined.common.network.messages.hums.ChangeHumMessage;
-import whocraft.tardis_refined.common.network.messages.screens.C2SRequestShellSelection;
-import whocraft.tardis_refined.common.network.messages.screens.OpenMonitorMessage;
-import whocraft.tardis_refined.common.network.messages.screens.OpenShellSelectionScreen;
+import whocraft.tardis_refined.common.network.messages.screens.*;
 import whocraft.tardis_refined.common.network.messages.sync.*;
 import whocraft.tardis_refined.common.network.messages.upgrades.S2CDisplayUpgradeScreen;
 import whocraft.tardis_refined.common.network.messages.upgrades.UnlockUpgradeMessage;
@@ -22,7 +20,7 @@ public class TardisNetwork {
     public static MessageType OPEN_SHELL_SELECT, SYNC_HUMS, OPEN_WAYPOINTS_DISPLAY, DEL_WAYPOINT, CLIENT_OPEN_COORDS_DISPLAY, SERVER_OPEN_COORDS_DISPLAY, UPGRADE_SCREEN_S2C,
             REQUEST_SHELL_C2S, CLIENT_OPEN_COORDS_SCREEN, SERVER_OPEN_COORDS_SCREEN, CLIENT_OPEN_EDIT_COORDS_SCREEN, SERVER_OPEN_EDIT_COORDS_SCREEN, UPLOAD_WAYPOINT,
             EDIT_WAYPOINT, SET_WAYPOINT, CHANGE_HUM, REQUEST_WAYPOINTS, SYNC_DESKTOPS, SYNC_CONSOLE_PATTERNS, SYNC_SHELL_PATTERNS, SYNC_LEVELS, INT_REACTION,
-            OPEN_MONITOR, CHANGE_SHELL, CHANGE_DESKTOP, CANCEL_CHANGE_DESKTOP, UNLOCK_UPGRADE, EJECT_PLAYER;
+            OPEN_MONITOR, CHANGE_SHELL, CHANGE_DESKTOP, CANCEL_CHANGE_DESKTOP, UNLOCK_UPGRADE, EJECT_PLAYER, MONITOR_POSITION_DATA, MONITOR_CLOSED;
 
     public static void init() {
         // S2C Messages
@@ -39,6 +37,7 @@ public class TardisNetwork {
         SERVER_OPEN_COORDS_SCREEN = NETWORK.registerS2C("server_open_coords_screen", S2COpenCoordinatesDisplayMessage::new);
         SYNC_HUMS = NETWORK.registerS2C("sync_hums", SyncHumsMessage::new);
         UPGRADE_SCREEN_S2C = NETWORK.registerS2C("upgrade_screen_s2c", S2CDisplayUpgradeScreen::new);
+        MONITOR_POSITION_DATA = NETWORK.registerS2C("monitor_position_data", MonitorPositionDataMessage::new);
 
         // C2S Messages
         CHANGE_SHELL = NETWORK.registerC2S("change_shell", ChangeShellMessage::new);
@@ -56,6 +55,7 @@ public class TardisNetwork {
         REQUEST_SHELL_C2S = NETWORK.registerC2S("request_shell_c2s", C2SRequestShellSelection::new);
         CHANGE_HUM = NETWORK.registerC2S("change_hum", ChangeHumMessage::new);
         EJECT_PLAYER = NETWORK.registerC2S("eject_player", EjectPlayerFromConsoleMessage::new);
+        MONITOR_CLOSED = NETWORK.registerC2S("monitor_closed", C2SMonitorClosed::new);
     }
 
 

--- a/common/src/main/java/whocraft/tardis_refined/common/network/messages/screens/C2SMonitorClosed.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/network/messages/screens/C2SMonitorClosed.java
@@ -1,0 +1,43 @@
+package whocraft.tardis_refined.common.network.messages.screens;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+import whocraft.tardis_refined.common.capability.TardisLevelOperator;
+import whocraft.tardis_refined.common.network.MessageC2S;
+import whocraft.tardis_refined.common.network.MessageContext;
+import whocraft.tardis_refined.common.network.MessageType;
+import whocraft.tardis_refined.common.network.TardisNetwork;
+import whocraft.tardis_refined.common.util.Platform;
+
+public class C2SMonitorClosed extends MessageC2S {
+
+    private ResourceKey<Level> level;
+
+    public C2SMonitorClosed(ResourceKey<Level> level) {
+        this.level = level;
+    }
+
+    public C2SMonitorClosed(FriendlyByteBuf friendlyByteBuf) {
+        this.level = friendlyByteBuf.readResourceKey(Registries.DIMENSION);
+    }
+
+    @Override
+    public @NotNull MessageType getType() {
+        return TardisNetwork.MONITOR_CLOSED;
+    }
+
+    @Override
+    public void toBytes(FriendlyByteBuf buf) {
+        buf.writeResourceKey(level);
+    }
+
+    @Override
+    public void handle(MessageContext context) {
+        TardisLevelOperator.get(Platform.getServer().getLevel(level)).ifPresent(operator -> {
+            operator.updatingMonitors.remove(context.getPlayer());
+        });
+    }
+}

--- a/common/src/main/java/whocraft/tardis_refined/common/network/messages/screens/MonitorPositionDataMessage.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/network/messages/screens/MonitorPositionDataMessage.java
@@ -1,0 +1,42 @@
+package whocraft.tardis_refined.common.network.messages.screens;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import org.jetbrains.annotations.NotNull;
+import whocraft.tardis_refined.TardisRefined;
+import whocraft.tardis_refined.common.network.MessageContext;
+import whocraft.tardis_refined.common.network.MessageS2C;
+import whocraft.tardis_refined.common.network.MessageType;
+import whocraft.tardis_refined.common.network.TardisNetwork;
+import whocraft.tardis_refined.common.tardis.TardisNavLocation;
+
+public class MonitorPositionDataMessage extends MessageS2C {
+
+    public static TardisNavLocation lastLocation = TardisNavLocation.ORIGIN;
+
+    TardisNavLocation location;
+
+    public MonitorPositionDataMessage(TardisNavLocation location) {
+        this.location = location;
+    }
+
+    public MonitorPositionDataMessage(FriendlyByteBuf friendlyByteBuf) {
+        CompoundTag tardisNav = friendlyByteBuf.readNbt();
+        this.location = TardisNavLocation.deserialize(tardisNav);
+    }
+
+    @Override
+    public @NotNull MessageType getType() {
+        return TardisNetwork.MONITOR_POSITION_DATA;
+    }
+
+    @Override
+    public void toBytes(FriendlyByteBuf buf) {
+        buf.writeNbt(location.serialise());
+    }
+
+    @Override
+    public void handle(MessageContext context) {
+        lastLocation = location;
+    }
+}

--- a/common/src/main/java/whocraft/tardis_refined/common/network/messages/screens/OpenMonitorMessage.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/network/messages/screens/OpenMonitorMessage.java
@@ -2,8 +2,11 @@ package whocraft.tardis_refined.common.network.messages.screens;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 import whocraft.tardis_refined.client.ScreenHandler;
 import whocraft.tardis_refined.common.capability.upgrades.UpgradeHandler;
@@ -19,13 +22,14 @@ public class OpenMonitorMessage extends MessageS2C {
     private final boolean desktopGenerating;
     private TardisNavLocation currentLocation, targetLocation;
     private CompoundTag upgradeHandlerNbt;
+    private ResourceKey<Level> tardisId;
 
-    public OpenMonitorMessage(boolean desktopGenerating, TardisNavLocation currentLocation, TardisNavLocation targetLocation, UpgradeHandler upgradeHandler) {
+    public OpenMonitorMessage(boolean desktopGenerating, TardisNavLocation currentLocation, TardisNavLocation targetLocation, UpgradeHandler upgradeHandler, ResourceKey<Level> tardisId) {
         this.desktopGenerating = desktopGenerating;
         this.currentLocation = currentLocation;
         this.targetLocation = targetLocation;
         this.upgradeHandlerNbt = upgradeHandler.saveData(new CompoundTag());
-
+        this.tardisId = tardisId;
     }
 
     public OpenMonitorMessage(FriendlyByteBuf friendlyByteBuf) {
@@ -33,6 +37,7 @@ public class OpenMonitorMessage extends MessageS2C {
         this.currentLocation = TardisNavLocation.deserialize(friendlyByteBuf.readNbt());
         this.targetLocation = TardisNavLocation.deserialize(friendlyByteBuf.readNbt());
         this.upgradeHandlerNbt = friendlyByteBuf.readNbt();
+        this.tardisId = friendlyByteBuf.readResourceKey(Registries.DIMENSION);
     }
 
     @NotNull
@@ -47,6 +52,7 @@ public class OpenMonitorMessage extends MessageS2C {
         buf.writeNbt(currentLocation.serialise());
         buf.writeNbt(targetLocation.serialise());
         buf.writeNbt(upgradeHandlerNbt);
+        buf.writeResourceKey(tardisId);
     }
 
 
@@ -58,7 +64,7 @@ public class OpenMonitorMessage extends MessageS2C {
     @Environment(EnvType.CLIENT)
     private void handleScreens() {
         // Open the monitor.
-        ScreenHandler.openMonitorScreen(desktopGenerating, upgradeHandlerNbt, currentLocation, targetLocation);
+        ScreenHandler.openMonitorScreen(desktopGenerating, upgradeHandlerNbt, currentLocation, targetLocation, tardisId);
     }
 
 }

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/TardisNavLocation.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/TardisNavLocation.java
@@ -142,9 +142,16 @@ public class TardisNavLocation {
 
     public TardisNavLocation copy() {
         TardisNavLocation copy = new TardisNavLocation(this.position, this.direction, this.dimensionKey);
+        if (this.level != null) {
+            copy.level = this.level;
+        }
         copy.setName(this.name);
         return copy;
     }
 
+    @Override
+    public String toString() {
+        return "TardisNavLocation{Pos=(%s), Dim=%s, Dir=%s, Name=%s}".formatted(this.position.toShortString(), this.dimensionKey.location(), this.direction.getName(), this.name);
+    }
 
 }

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/RandomControl.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/RandomControl.java
@@ -10,6 +10,8 @@ import whocraft.tardis_refined.common.tardis.control.Control;
 import whocraft.tardis_refined.common.tardis.manager.TardisPilotingManager;
 import whocraft.tardis_refined.common.tardis.themes.ConsoleTheme;
 import whocraft.tardis_refined.common.util.PlayerUtil;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 
 public class RandomControl extends Control {
     public RandomControl(ResourceLocation id) {
@@ -26,7 +28,10 @@ public class RandomControl extends Control {
             TardisPilotingManager pilotManager = operator.getPilotingManager();
 
             int increment = pilotManager.getCordIncrement();
-            BlockPos currentExLoc = operator.getPilotingManager().getCurrentLocation().getPosition();
+            BlockPos currentExLoc = pilotManager.getCurrentLocation().getPosition();
+            if (ModCompatChecker.valkyrienSkies()) {
+                currentExLoc = VSHelper.toWorldPosition(pilotManager.getCurrentLocation().getLevel(), currentExLoc);
+            }
             pilotManager.getTargetLocation().setPosition(
                     new BlockPos((currentExLoc.getX() - (increment / 2)) + operator.getLevel().random.nextInt(increment * 2),
                             150,

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/ReadoutControl.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/ReadoutControl.java
@@ -1,7 +1,10 @@
 package whocraft.tardis_refined.common.tardis.control.flight;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
 import whocraft.tardis_refined.common.capability.TardisLevelOperator;
 import whocraft.tardis_refined.common.entity.ControlEntity;
@@ -9,6 +12,8 @@ import whocraft.tardis_refined.common.tardis.TardisNavLocation;
 import whocraft.tardis_refined.common.tardis.control.Control;
 import whocraft.tardis_refined.common.tardis.themes.ConsoleTheme;
 import whocraft.tardis_refined.common.util.PlayerUtil;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 import whocraft.tardis_refined.constants.ModMessages;
 
 public class ReadoutControl extends Control {
@@ -23,8 +28,15 @@ public class ReadoutControl extends Control {
     @Override
     public boolean onLeftClick(TardisLevelOperator operator, ConsoleTheme theme, ControlEntity controlEntity, Player player) {
 
-        TardisNavLocation currentPosition = operator.getPilotingManager().getCurrentLocation();
-        PlayerUtil.sendMessage(player, Component.translatable(ModMessages.CURRENT).append(" - X: " + currentPosition.getPosition().getX() + " Y: " + currentPosition.getPosition().getY() + " Z: " + currentPosition.getPosition().getZ() + " F: " + currentPosition.getDirection().getName() + " D: " + currentPosition.getDimensionKey().location().getPath()), true);
+        TardisNavLocation loc = operator.getPilotingManager().getCurrentLocation();
+        if (ModCompatChecker.valkyrienSkies()) {
+            loc = VSHelper.toWorldLocation(loc);
+        }
+        BlockPos position = loc.getPosition();
+        Direction direction = loc.getDirection();
+        ServerLevel level = loc.getLevel();
+
+        PlayerUtil.sendMessage(player, Component.translatable(ModMessages.CURRENT).append(" - X: " + position.getX() + " Y: " + position.getY() + " Z: " + position.getZ() + " F: " + direction.getName() + " D: " + level.dimension().location().getPath()), true);
 
 
         return true;

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/control/ship/MonitorControl.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/control/ship/MonitorControl.java
@@ -9,10 +9,13 @@ import whocraft.tardis_refined.common.capability.TardisLevelOperator;
 import whocraft.tardis_refined.common.entity.ControlEntity;
 import whocraft.tardis_refined.common.items.KeyItem;
 import whocraft.tardis_refined.common.network.messages.screens.OpenMonitorMessage;
+import whocraft.tardis_refined.common.tardis.TardisNavLocation;
 import whocraft.tardis_refined.common.tardis.control.Control;
 import whocraft.tardis_refined.common.tardis.control.ControlSpecification;
 import whocraft.tardis_refined.common.tardis.themes.ConsoleTheme;
 import whocraft.tardis_refined.common.util.PlayerUtil;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 import whocraft.tardis_refined.constants.ModMessages;
 
 public class MonitorControl extends Control {
@@ -39,8 +42,21 @@ public class MonitorControl extends Control {
                 if (key.interactMonitor(hand,player, controlEntity, player.getUsedItemHand()))
                     isSyncingKey = true;
             }
-            if (!isSyncingKey)
-                new OpenMonitorMessage(operator.getInteriorManager().isWaitingToGenerate(), operator.getPilotingManager().getCurrentLocation(), operator.getPilotingManager().getTargetLocation(), operator.getUpgradeHandler()).send((ServerPlayer) player);
+            if (!isSyncingKey) {
+                TardisNavLocation currentLocation = operator.getPilotingManager().getCurrentLocation();
+                if (ModCompatChecker.valkyrienSkies()) {
+                    currentLocation = VSHelper.toWorldLocation(currentLocation);
+                }
+
+                new OpenMonitorMessage(
+                    operator.getInteriorManager().isWaitingToGenerate(),
+                    currentLocation,
+                    operator.getPilotingManager().getTargetLocation(),
+                    operator.getUpgradeHandler(),
+                    operator.getLevelKey()
+                ).send((ServerPlayer) player);
+                operator.updatingMonitors.add((ServerPlayer) player);
+            }
             return true;
         }
         return false;

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisExteriorManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisExteriorManager.java
@@ -158,6 +158,8 @@ public class TardisExteriorManager extends BaseHandler {
         BlockPos lastKnownLocationPosition = location.getPosition();
         ChunkPos chunkPos = location.getLevel().getChunk(lastKnownLocationPosition).getPos();
 
+        this.isLanding = true;
+
         //Force load target chunk
         targetLevel.setChunkForced(chunkPos.x, chunkPos.z, true); //Set chunk to be force loaded to properly place block
 
@@ -165,8 +167,6 @@ public class TardisExteriorManager extends BaseHandler {
 
         //Un-force load target chunk
         targetLevel.setChunkForced(chunkPos.x, chunkPos.z, false); //Set chunk to be not be force loaded after we place the block
-
-        this.isLanding = true;
     }
 
     /** Convenience method to place the exterior block when the Tardis is landing */

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -607,7 +607,7 @@ public class TardisPilotingManager extends TickableHandler {
      * @return true if able to, false if not
      */
     public boolean canEndFlight() {
-        return isInFlight && ticksInFlight >= (20 * 5) && ticksTakingOff <= 0 && (distanceCovered >= flightDistance || this.autoLand) && !this.isCrashing;
+        return isInFlight && ticksTakingOff <= 0 && (distanceCovered >= flightDistance || this.autoLand) && !this.isCrashing;
     }
 
     public void recalculateFlightDistance() {

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -218,7 +218,7 @@ public class TardisPilotingManager extends TickableHandler {
     private void onFlightTick(ServerLevel level) {
         // Don't continue the flight if the throttle isn't active!!!
 
-        if (this.throttleStage != 0 || this.autoLand) {
+        if (this.ticksTakingOff == 0 && (this.throttleStage != 0 || this.autoLand)) {
             ticksInFlight++;
 
             // Removing fuel once every 2.5 seconds

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -899,20 +899,23 @@ public class TardisPilotingManager extends TickableHandler {
             newLocation.getLevel().removeBlock(newLocation.getPosition(), false);
             return;
         }
+
+        ServerLevel currentLevel = this.currentLocation.getLevel();
+
         boolean shellExistsSomewhereElse = false;
         // if the new position is different
-        if (!this.currentLocation.getLevel().equals(newLocation.getLevel())
+        if (!currentLevel.equals(newLocation.getLevel())
             || !this.currentLocation.getPosition().equals(newLocation.getPosition())
         ) {
             // if there is a tardis at the old current location
-            if (this.currentLocation.getLevel().getBlockState(this.currentLocation.getPosition()).getBlock() instanceof ShellBaseBlock
-                && this.currentLocation.getLevel().getBlockEntity(this.currentLocation.getPosition()) instanceof ShellBaseBlockEntity shellBlockEntity
+            if (currentLevel.getBlockState(this.currentLocation.getPosition()).getBlock() instanceof ShellBaseBlock
+                && currentLevel.getBlockEntity(this.currentLocation.getPosition()) instanceof ShellBaseBlockEntity shellBlockEntity
             ) {
                 // and it is the same tardis id
                 if (shellBlockEntity.getTardisId().equals(this.operator.getLevel().dimension())) {
                     if (ModCompatChecker.valkyrienSkies()) {
-                        boolean inshipyard = VSHelper.isBlockInShipyard(this.currentLocation.getLevel(), this.currentLocation.getPosition());
-                        boolean onShip = VSHelper.isBlockOnShip(this.currentLocation.getLevel(), this.currentLocation.getPosition());
+                        boolean inshipyard = VSHelper.isBlockInShipyard(currentLevel, this.currentLocation.getPosition());
+                        boolean onShip = VSHelper.isBlockOnShip(currentLevel, this.currentLocation.getPosition());
                         shellExistsSomewhereElse = onShip || !inshipyard;
                     } else {
                         shellExistsSomewhereElse = true;

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -476,7 +476,7 @@ public class TardisPilotingManager extends TickableHandler {
 
     /** Finds the closest valid position out of a list of possible solutions, from the original intended landing location*/
     private TardisNavLocation findClosestValidPositionFromTarget(List<TardisNavLocation> validPositions, TardisNavLocation targetLocation){
-        double distance = Integer.MAX_VALUE;
+        double distance = Double.MAX_VALUE;
         TardisNavLocation intendedLocation = targetLocation;
         Vec3 intendedPosition = targetLocation.getPosition().getCenter();
         TardisNavLocation closestSolution = new TardisNavLocation(BlockPos.ZERO, Direction.NORTH, intendedLocation.getLevel());

--- a/common/src/main/java/whocraft/tardis_refined/common/util/TRTeleporter.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/util/TRTeleporter.java
@@ -424,14 +424,10 @@ public class TRTeleporter {
      * @return
      */
     public static boolean teleportIfCollided(ServerLevel serverLevel, BlockPos blockPos, Entity entity, AABB teleportAABB) {
-        AABB entityBoundingBox = TRTeleporter.getBoundingBoxWithMovement(entity);
         double insideBlockExpansion = 1.0E-7D; //Hardcoded value replicates logic from Entity#checkInsideBlocks
-        AABB inflatedEntityBoundingBox = entityBoundingBox.inflate(insideBlockExpansion);
         AABB inflatedTeleportBoundingBox = teleportAABB.inflate(insideBlockExpansion);
-        if (inflatedTeleportBoundingBox.intersects(inflatedEntityBoundingBox)) {
-            return true;
-        }
-        return false;
+
+        return !serverLevel.getEntities((Entity) null, inflatedTeleportBoundingBox, entity1 -> entity1 == entity).isEmpty();
     }
 
     /**

--- a/common/src/main/java/whocraft/tardis_refined/common/util/TardisHelper.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/util/TardisHelper.java
@@ -17,6 +17,8 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.Vec3;
+import org.joml.Math;
+import org.joml.Vector3d;
 import whocraft.tardis_refined.api.event.ShellChangeSource;
 import whocraft.tardis_refined.api.event.ShellChangeSources;
 import whocraft.tardis_refined.api.event.TardisCommonEvents;
@@ -33,6 +35,8 @@ import whocraft.tardis_refined.common.tardis.manager.TardisExteriorManager;
 import whocraft.tardis_refined.common.tardis.manager.TardisInteriorManager;
 import whocraft.tardis_refined.common.tardis.manager.TardisPilotingManager;
 import whocraft.tardis_refined.common.tardis.themes.DesktopTheme;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 import whocraft.tardis_refined.patterns.ShellPatterns;
 import whocraft.tardis_refined.registry.TRBlockRegistry;
 import whocraft.tardis_refined.registry.TRDimensionTypes;
@@ -123,6 +127,29 @@ public class TardisHelper {
     }
 
     public static boolean teleportEntityTardis(TardisLevelOperator cap, Entity entity, TardisNavLocation sourceLocation, TardisNavLocation destinationLocation, boolean enterTardis) {
+        float sourceYawRotation, destinationYawRotation;
+        if (ModCompatChecker.valkyrienSkies()) {
+            Vector3d sourceDirection = VSHelper.toWorldRotation(
+                sourceLocation.getLevel(),
+                sourceLocation.getPosition(),
+                sourceLocation.getDirection()
+            );
+            sourceYawRotation = (float) Math.toDegrees(-Math.atan2(sourceDirection.x, sourceDirection.z));
+            Vector3d destinationDirection = VSHelper.toWorldRotation(
+                destinationLocation.getLevel(),
+                destinationLocation.getPosition(),
+                destinationLocation.getDirection()
+            );
+            destinationYawRotation = (float) Math.toDegrees(-Math.atan2(destinationDirection.x, destinationDirection.z));
+        } else {
+            sourceYawRotation = sourceLocation.getDirection().toYRot();
+            destinationYawRotation = destinationLocation.getDirection().toYRot();
+        }
+
+        return teleportEntityTardis(cap, entity, sourceLocation, sourceYawRotation, destinationLocation, destinationYawRotation, enterTardis);
+    }
+
+    public static boolean teleportEntityTardis(TardisLevelOperator cap, Entity entity, TardisNavLocation sourceLocation, float sourceRotationYaw, TardisNavLocation destinationLocation, float destinationRotationYaw, boolean enterTardis) {
 
         if (entity.level() instanceof ServerLevel teleportingEntityLevel) {
 
@@ -144,8 +171,6 @@ public class TardisHelper {
 
             //Calculate entity motion and rotation, taking into account for the internal door's direction and rotation
             float entityYRot = entity.getYRot();
-            float destinationRotationYaw = destinationDirection.toYRot();
-            float sourceRotationYaw = sourceDirection.toYRot();
             //Calculate the difference between the entity's rotation and the source direction's rotation. Get the difference and find the final rotation that preserves the entities' rotation but facing the direction at the destination
             float diff = LevelHelper.getAdjustedRotation(entityYRot) - LevelHelper.getAdjustedRotation(sourceRotationYaw);
 

--- a/common/src/main/java/whocraft/tardis_refined/common/world/chunk/TardisChunkGenerator.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/world/chunk/TardisChunkGenerator.java
@@ -27,6 +27,8 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlac
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
 import whocraft.tardis_refined.TardisRefined;
 import whocraft.tardis_refined.common.world.ChunkGenerators;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 import whocraft.tardis_refined.constants.TardisDimensionConstants;
 import whocraft.tardis_refined.registry.TRARSStructurePieceRegistry;
 import whocraft.tardis_refined.registry.TRBlockRegistry;
@@ -130,6 +132,12 @@ public class TardisChunkGenerator extends ChunkGenerator {
             return;
         }
 
+        if (ModCompatChecker.valkyrienSkies()) {
+            if (VSHelper.isChunkInShipyard(pChunk.getPos())) {
+                return;
+            }
+        }
+
         if (pChunk.getPos().x % arsChunkSize == 0 && pChunk.getPos().z % arsChunkSize == 0) {
 
             if (isChunkAtGravityInterval(pChunk.getPos())) {
@@ -196,8 +204,12 @@ public class TardisChunkGenerator extends ChunkGenerator {
     }
 
     @Override
-    public CompletableFuture<ChunkAccess> fillFromNoise(Executor executor, Blender p_223210_, RandomState p_223211_, StructureManager p_223212_, ChunkAccess access) {
-
+    public CompletableFuture<ChunkAccess> fillFromNoise(Executor executor, Blender blender, RandomState randomState, StructureManager structureManager, ChunkAccess access) {
+        if (ModCompatChecker.valkyrienSkies()) {
+            if (VSHelper.isChunkInShipyard(access.getPos())) {
+                return CompletableFuture.completedFuture(access);
+            }
+        }
         // Flatworlds appear to use this function instead of the surface.
         BlockPos cornerPos = new BlockPos(access.getPos().getMinBlockX(), TardisDimensionConstants.TARDIS_ROOT_GENERATION_MIN_HEIGHT - 5, access.getPos().getMinBlockZ());
         BlockPos lastCornerPos = new BlockPos(access.getPos().getMaxBlockX(), TardisDimensionConstants.TARDIS_ROOT_GENERATION_MAX_HEIGHT + 5, access.getPos().getMaxBlockZ());

--- a/common/src/main/java/whocraft/tardis_refined/compat/ModCompatChecker.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/ModCompatChecker.java
@@ -16,4 +16,8 @@ public class ModCompatChecker {
     public static boolean create() {
         return Platform.isModLoaded("create");
     }
+
+    public static boolean valkyrienSkies() {
+        return Platform.isModLoaded("valkyrienskies");
+    }
 }

--- a/common/src/main/java/whocraft/tardis_refined/compat/create/CreateIntergrations.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/create/CreateIntergrations.java
@@ -8,6 +8,8 @@ import net.minecraft.resources.ResourceLocation;
 import whocraft.tardis_refined.TardisRefined;
 import whocraft.tardis_refined.common.capability.TardisLevelOperator;
 import whocraft.tardis_refined.common.tardis.TardisNavLocation;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 import whocraft.tardis_refined.constants.ModMessages;
 
 import java.util.ArrayList;
@@ -70,7 +72,11 @@ public class CreateIntergrations {
         registerBehaviour(new TardisNavLocationDisplaySource.TardisNavInfo() {
             @Override
             public TardisNavLocation provideInfo(TardisLevelOperator tardisLevelOperator) {
-                return tardisLevelOperator.getPilotingManager().getCurrentLocation();
+                TardisNavLocation currentLoc = tardisLevelOperator.getPilotingManager().getCurrentLocation();
+                if (ModCompatChecker.valkyrienSkies()) {
+                    currentLoc = VSHelper.toWorldLocation(currentLoc);
+                }
+                return currentLoc;
             }
 
             @Override

--- a/common/src/main/java/whocraft/tardis_refined/compat/create/TardisDisplaySource.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/create/TardisDisplaySource.java
@@ -10,7 +10,10 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import whocraft.tardis_refined.common.blockentity.device.FlightDetectorBlockEntity;
 import whocraft.tardis_refined.common.capability.TardisLevelOperator;
+import whocraft.tardis_refined.common.tardis.TardisNavLocation;
 import whocraft.tardis_refined.common.util.MiscHelper;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 import whocraft.tardis_refined.constants.ModMessages;
 
 import java.util.ArrayList;
@@ -33,9 +36,14 @@ public class TardisDisplaySource extends DisplaySource {
                 boolean isPresent = TardisLevelOperator.get(serverLevel).isPresent();
                 if (isPresent) {
                     TardisLevelOperator levelOperator = TardisLevelOperator.get(serverLevel).get();
+                    TardisNavLocation currentLoc = levelOperator.getPilotingManager().getCurrentLocation();
+                    if (ModCompatChecker.valkyrienSkies()) {
+                        currentLoc = VSHelper.toWorldLocation(currentLoc);
+                    }
+
                     list.add(levelOperator.getPilotingManager().isInFlight() ? Component.literal("In Flight: True") : Component.literal("In Flight: False"));
-                    list.add(Component.literal("Pos: " + levelOperator.getPilotingManager().getCurrentLocation().getPosition().toShortString()));
-                    list.add(Component.literal("Dim: " + MiscHelper.getCleanDimensionName(levelOperator.getPilotingManager().getCurrentLocation().getDimensionKey())));
+                    list.add(Component.literal("Pos: " + currentLoc.getPosition().toShortString()));
+                    list.add(Component.literal("Dim: " + MiscHelper.getCleanDimensionName(currentLoc.getDimensionKey())));
                     list.add(Component.translatable(ModMessages.FUEL).append(String.valueOf((Math.round((levelOperator.getPilotingManager().getFuelPercentage() * 100))))).append("%"));
                     list.add(Component.literal("Shell: " + levelOperator.getAestheticHandler().getShellTheme().getPath()));
                     list.add(Component.literal("Journey Progress: " + levelOperator.getPilotingManager().getFlightPercentageCovered() * 100 + "%"));

--- a/common/src/main/java/whocraft/tardis_refined/compat/valkyrienskies/VSHelper.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/valkyrienskies/VSHelper.java
@@ -1,0 +1,122 @@
+package whocraft.tardis_refined.compat.valkyrienskies;
+
+import net.fabricmc.loader.impl.lib.sat4j.core.Vec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Math;
+import org.joml.Vector3d;
+import org.joml.primitives.AABBd;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VS2ChunkAllocator;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
+import whocraft.tardis_refined.common.tardis.TardisNavLocation;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+public class VSHelper {
+    public static boolean isChunkInShipyard(ChunkPos pos) {
+        return VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(pos.x, pos.z);
+    }
+
+    public static boolean isBlockInShipyard(Level level, BlockPos pos) {
+        return VSGameUtilsKt.isBlockInShipyard(level, pos);
+    }
+
+    public static void forEachShipInAABB(Level level, AABB aabb, Consumer<AABB> consumer) {
+        AABBd worldAABB = VectorConversionsMCKt.toJOML(aabb);
+        for (Ship ship : VSGameUtilsKt.getShipsIntersecting(level, aabb)) {
+            consumer.accept(VectorConversionsMCKt.toMinecraft(worldAABB.transform(ship.getWorldToShip())));
+        }
+    }
+
+    public static boolean collidesWithShip(Level level, AABB boundingBox) {
+        // not an exact collision, because we use an axis-aligned bounding box, but good enough
+        AABBd bb = VectorConversionsMCKt.toJOML(boundingBox);
+        Ship currentShip = VSGameUtilsKt.getShipManagingPos(level, boundingBox.getCenter());
+        if (currentShip != null) {
+            bb.transform(currentShip.getShipToWorld());
+        }
+
+        for(Ship ship : VSGameUtilsKt.getShipsIntersecting(level, bb)) {
+            if (ship == currentShip)
+                continue;
+
+            AABBd transformedBB = bb.transform(ship.getWorldToShip(), new AABBd());
+            Stream<BlockPos> blocks = BlockPos.betweenClosedStream(VectorConversionsMCKt.toMinecraft(transformedBB));
+            boolean bbEmpty = blocks.allMatch(blockPos -> {
+                BlockState state = level.getBlockState(blockPos);
+                return state.getCollisionShape(level, blockPos).isEmpty() && state.getFluidState().isEmpty();
+            });
+            if (!bbEmpty)
+                return true;
+        }
+        return false;
+    }
+
+    public static boolean isBlockOnShip(Level level, BlockPos pos) {
+        Ship ship = VSGameUtilsKt.getShipManagingPos(level, pos);
+        var ships = VSGameUtilsKt.getShipsIntersecting(level, new AABB(0, 0, 0, 0, 0, 0));
+        if (ship == null) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public static Vector3d toWorldRotation(Level level, BlockPos position, Direction direction) {
+        Ship ship = VSGameUtilsKt.getShipManagingPos(level, position);
+        if (ship != null) {
+            return ship.getShipToWorld().transformDirection(directionToVector(direction));
+        } else {
+            return directionToVector(direction);
+        }
+    }
+
+    public static BlockPos toWorldPosition(Level level, BlockPos blockPos) {
+        Vector3d pos = blockPosToVector(blockPos);
+        Vector3d worldPos = VSGameUtilsKt.getWorldCoordinates(level, blockPos, pos);
+        return vectorToBlockPos(worldPos);
+    }
+
+    public static Vec3 toWorldPosition(Level level, BlockPos blockPos, Vec3 vector) {
+        Vector3d pos = VectorConversionsMCKt.toJOML(vector);
+        Vector3d worldPos = VSGameUtilsKt.getWorldCoordinates(level, blockPos, pos);
+        return VectorConversionsMCKt.toMinecraft(worldPos);
+    }
+
+    public static TardisNavLocation toWorldLocation(TardisNavLocation input) {
+        Ship ship = VSGameUtilsKt.getShipManagingPos(input.getLevel(), input.getPosition());
+        if (ship != null) {
+            BlockPos pos = vectorToBlockPos(ship.getShipToWorld().transformPosition(blockPosToVector(input.getPosition())));
+            Direction dir = vectorToDirection(ship.getShipToWorld().transformDirection(directionToVector(input.getDirection())));
+            TardisNavLocation output = new TardisNavLocation(pos, dir, input.getLevel());
+            output.setName(input.getName());
+            return output;
+        } else {
+            return input;
+        }
+    }
+
+    public static Vector3d blockPosToVector(BlockPos blockPos) {
+        return new Vector3d(blockPos.getX(), blockPos.getY(), blockPos.getZ());
+    }
+
+    public static BlockPos vectorToBlockPos(Vector3d vector) {
+        return new BlockPos((int) Math.round(vector.x), (int) Math.round(vector.y), (int) Math.round(vector.z));
+    }
+
+    public static Vector3d directionToVector(Direction direction) {
+        return new Vector3d(direction.getStepX(), direction.getStepY(), direction.getStepZ());
+    }
+
+    public static Direction vectorToDirection(Vector3d vector) {
+        return Direction.getNearest(vector.x, vector.y, vector.z);
+    }
+}

--- a/fabric/src/main/java/whocraft/tardis_refined/fabric/events/ModEvents.java
+++ b/fabric/src/main/java/whocraft/tardis_refined/fabric/events/ModEvents.java
@@ -26,6 +26,7 @@ import whocraft.tardis_refined.common.dimension.fabric.DimensionHandlerImpl;
 import whocraft.tardis_refined.common.util.MiscHelper;
 import whocraft.tardis_refined.common.util.TardisHelper;
 import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.create.CreateIntergrations;
 import whocraft.tardis_refined.compat.portals.ImmersivePortals;
 import whocraft.tardis_refined.registry.TRDimensionTypes;
 import whocraft.tardis_refined.registry.TRItemRegistry;
@@ -49,6 +50,9 @@ public class ModEvents {
             ServerLevel world = server.getLevel(Level.OVERWORLD);
             DimensionHandler.loadLevels(world);
 
+            if (ModCompatChecker.create()) {
+                CreateIntergrations.init();
+            }
         });
 
         ServerTickEvents.START_SERVER_TICK.register(ControlGroupCheckers::tickServer);

--- a/forge/src/main/java/whocraft/tardis_refined/forge/CommonBus.java
+++ b/forge/src/main/java/whocraft/tardis_refined/forge/CommonBus.java
@@ -22,6 +22,8 @@ import whocraft.tardis_refined.common.hum.TardisHums;
 import whocraft.tardis_refined.common.tardis.TardisDesktops;
 import whocraft.tardis_refined.common.util.MiscHelper;
 import whocraft.tardis_refined.common.util.TardisHelper;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.create.CreateIntergrations;
 import whocraft.tardis_refined.patterns.ConsolePatterns;
 import whocraft.tardis_refined.patterns.ShellPatterns;
 
@@ -44,6 +46,9 @@ public class CommonBus {
         ServerLevel world = event.getServer().getLevel(Level.OVERWORLD);
         DimensionHandler.loadLevels(world);
 
+        if (ModCompatChecker.create()) {
+            CreateIntergrations.init();
+        }
     }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,7 @@ fabric_api_version_range=>=0.92.1+1.20.1
 fabric_loader_version_range=>=0.7.4
 fabric_minecraft_version_range=>=1.20.1
 fabric_immersive_portals_version_range=>=2.6.6
+fabric_valkyrienskies_version_range=>=2.3.0-beta.1
 
 #Forge
 forge_version=47.2.32
@@ -34,6 +35,7 @@ forge_resource_pack_format=12
 forge_data_pack_format=12
 pack_format=12
 forge_immersive_portals_version_range = [2.5.4,)
+forge_valkyrienskies_version_range = [2.3.0-beta.1,)
 
 ##Mod Information
 
@@ -93,3 +95,4 @@ create_version_plain = 0.5.1.f
 flywheel_version_fabric = 0.6.10-2
 flywheel_version_forge = 0.6.10-8
 flywheel_minecraft_version=1.20.1
+valkyrienskies_version=2.3.0-beta.5


### PR DESCRIPTION
While the last PR to fix the crash issue when both Valkyrien Skies and Tardis Refined are loaded was nice, the mods couldn't really interact in any way.
This PR changes a bunch of things to improve that.
It is now possible to:
- Enter/exit a tardis that is on a VS ship
- Land on and take off from VS ships with a tardis, using normal world coordinates
- See a live-updating location of the tardis on its monitor while on a moving VS ship
- Create a VS ship inside a tardis
- Pick up and move a tardis using some other tile-entity moving mod like 'Packing Tape'

There are also some other small changes/fixes in seperate commits, such as re-enabling integration with the Create mod. (was this removed by accident?)