### PR TITLE
Allow bed respawning if the TARDIS has the upgrade for it

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/mixin/ServerPlayerMixin.java
+++ b/common/src/main/java/whocraft/tardis_refined/mixin/ServerPlayerMixin.java
@@ -2,32 +2,52 @@ package whocraft.tardis_refined.mixin;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import whocraft.tardis_refined.common.capability.tardis.TardisLevelOperator;
 import whocraft.tardis_refined.common.util.PlayerUtil;
 import whocraft.tardis_refined.constants.ModMessages;
 import whocraft.tardis_refined.registry.TRDimensionTypes;
+import whocraft.tardis_refined.registry.TRUpgrades;
 
 @Mixin(ServerPlayer.class)
-public class ServerPlayerMixin {
+public abstract class ServerPlayerMixin {
+
+
 
     @Inject(method = "stopSleepInBed(ZZ)V", at = @At("HEAD"))
     private void stopSleepInBed(boolean bl, boolean bl2, CallbackInfo ci) {
         ServerPlayer serverPlayer = (ServerPlayer) (Object) this;
-        if (serverPlayer.level().dimensionTypeId() == TRDimensionTypes.TARDIS) {
-            PlayerUtil.sendMessage(serverPlayer, ModMessages.TARDIS_SLEEP_END, true);
+        if (serverPlayer.serverLevel() != null) {
+            if (serverPlayer.level().dimensionTypeId() == TRDimensionTypes.TARDIS) {
+                TardisLevelOperator.get(serverPlayer.serverLevel()).ifPresent(x -> {
+                    var upgradeHandler = x.getUpgradeHandler();
+                    if (!upgradeHandler.isUpgradeUnlocked(TRUpgrades.RESPAWN_ALLOWED.get())) {
+                        PlayerUtil.sendMessage(serverPlayer, ModMessages.TARDIS_SLEEP_END, true);
+                    }
+                });
+            }
         }
     }
 
     @Inject(method = "setRespawnPosition(Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/core/BlockPos;FZZ)V", at = @At("HEAD"), cancellable = true)
     public void setRespawnPosition(ResourceKey<Level> resourceKey, BlockPos blockPos, float f, boolean bl, boolean bl2, CallbackInfo ci) {
         ServerPlayer serverPlayer = (ServerPlayer) (Object) this;
-        if(serverPlayer.level().dimensionTypeId() == TRDimensionTypes.TARDIS){
-            ci.cancel();
+        if (serverPlayer.serverLevel() != null) {
+            if (serverPlayer.level().dimensionTypeId() == TRDimensionTypes.TARDIS) {
+                TardisLevelOperator.get(serverPlayer.serverLevel()).ifPresent(x -> {
+                    var upgradeHandler = x.getUpgradeHandler();
+                    if (!upgradeHandler.isUpgradeUnlocked(TRUpgrades.RESPAWN_ALLOWED.get())) {
+                        ci.cancel();
+                    }
+                });
+            }
         }
     }
 

--- a/common/src/main/java/whocraft/tardis_refined/registry/TRUpgrades.java
+++ b/common/src/main/java/whocraft/tardis_refined/registry/TRUpgrades.java
@@ -39,6 +39,9 @@ public class TRUpgrades {
     public static final RegistrySupplier<Upgrade> INSIDE_ARCHITECTURE = UPGRADE_DEFERRED_REGISTRY.register("inside_architecture", () -> new Upgrade(TRBlockRegistry.TERRAFORMER_BLOCK.get().asItem()::getDefaultInstance, ARCHITECTURE_SYSTEM, RegistryHelper.makeKey("inside_architecture"), Upgrade.UpgradeType.SUB_UPGRADE)
             .setSkillPointsRequired(20).setPosition(4, 2));
 
+    public static final RegistrySupplier<Upgrade> RESPAWN_ALLOWED = UPGRADE_DEFERRED_REGISTRY.register("respawn_allowed", () -> new Upgrade(Items.RED_BED::getDefaultInstance, ARCHITECTURE_SYSTEM, RegistryHelper.makeKey("respawn_allowed"), Upgrade.UpgradeType.SUB_UPGRADE)
+            .setSkillPointsRequired(10).setPosition(3, 2));
+
     public static final RegistrySupplier<Upgrade> IMPROVED_GENERATION_TIME_I = UPGRADE_DEFERRED_REGISTRY.register("improved_generation_time_i", () -> new Upgrade(Items.TURTLE_EGG::getDefaultInstance, INSIDE_ARCHITECTURE, RegistryHelper.makeKey("improved_generation_time_i"), Upgrade.UpgradeType.SUB_UPGRADE)
             .setSkillPointsRequired(10).setPosition(4, 3));
     public static final RegistrySupplier<Upgrade> IMPROVED_GENERATION_TIME_II = UPGRADE_DEFERRED_REGISTRY.register("improved_generation_time_ii", () -> new Upgrade(Items.RABBIT_FOOT::getDefaultInstance, IMPROVED_GENERATION_TIME_I, RegistryHelper.makeKey("improved_generation_time_ii"), Upgrade.UpgradeType.SUB_UPGRADE)

--- a/forge/src/main/java/whocraft/tardis_refined/common/data/LangProviderEnglish.java
+++ b/forge/src/main/java/whocraft/tardis_refined/common/data/LangProviderEnglish.java
@@ -336,6 +336,7 @@ public class LangProviderEnglish extends LanguageProvider {
         addUpgrade(TRUpgrades.NAVIGATION_SYSTEM.get(), "Navigation System", "Allows upgrades to the TARDIS Navigation System");
         addUpgrade(TRUpgrades.TARDIS_XP.get(), "System Upgrades", "Allows upgrades to the TARDIS");
         addUpgrade(TRUpgrades.MATERIALIZE_AROUND.get(), "Materialize Around", "Allows the TARDIS to have entities enter while materalizing");
+        addUpgrade(TRUpgrades.RESPAWN_ALLOWED.get(), "Allow Bed Respawning", "Removes security restriction allowing users to set their spawn via beds.");
         addUpgrade(TRUpgrades.ARCHITECTURE_SYSTEM.get(), "Architecture", "Enables TARDIS Architecture Upgrades");
         addUpgrade(TRUpgrades.INSIDE_ARCHITECTURE.get(), "Desktop Reconfiguration", "Allows the Pilot to change the appearance of the TARDIS Desktop");
         addUpgrade(TRUpgrades.EXPLORER.get(), "Explorer I", "x1000 Increment");


### PR DESCRIPTION
Adds new upgrade to allow players to set their spawnpoint in the TARDIS.

Will require porting to 1.20.1.

![2025-06-26_15 15 24](https://github.com/user-attachments/assets/edf0b9ca-27c1-43ea-8d1e-6bc58233e45a)
