### PR TITLE
Fix TARDIS creation in other dimensions.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,5 +7,5 @@
 - Bug fix: Fixes Forge not having the same access level as Fabric (https://github.com/WhoCraft/TardisRefined/issues/477)
 - Bug fix: Fixed Shulker shells not having correct texture paths
 - Bug fix: Fixed the TARDIS forgetting its current dimension on world reload
-
+- Bug fix: Fixed TARDIS being broken when created in a non-overworld dimension.
 

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/TardisNavLocation.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/TardisNavLocation.java
@@ -92,6 +92,10 @@ public class TardisNavLocation {
             return DimensionUtil.getLevel(dimensionKey);
         }
 
+        var level = Platform.getServer().getLevel(dimensionKey);
+        if (level != null) {
+            return level;
+        }
         return Platform.getServer().getLevel(Level.OVERWORLD);
     }
 

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/DimensionalControl.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/control/flight/DimensionalControl.java
@@ -18,8 +18,6 @@ import whocraft.tardis_refined.registry.TRUpgrades;
 import java.util.ArrayList;
 import java.util.List;
 
-import static net.minecraft.world.level.Level.OVERWORLD;
-
 public class DimensionalControl extends Control {
     public DimensionalControl(ResourceLocation id) {
         super(id);
@@ -62,7 +60,7 @@ public class DimensionalControl extends Control {
 
             if (!TRUpgrades.DIMENSION_TRAVEL.get().isUnlocked(upgradeHandler)) {
                 PlayerUtil.sendMessage(player, Component.translatable(ModMessages.HARDWARE_OFFLINE), true);
-                pilotManager.getTargetLocation().setDimensionKey(OVERWORLD);
+                pilotManager.getTargetLocation().setDimensionKey(pilotManager.getCurrentLocation().getDimensionKey());
                 return false;
             }
 

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -116,8 +116,8 @@ public class TardisPilotingManager extends TickableHandler {
 
         this.isPassivelyRefuelling = tag.getBoolean(NbtConstants.IS_PASSIVELY_REFUELING);
 
-        setCurrentLocation(NbtConstants.getTardisNavLocation(tag, NbtConstants.CURRENT_LOCATION));
-        setTargetLocation(NbtConstants.getTardisNavLocation(tag, NbtConstants.TARGET_LOCATION));
+        this.currentLocation = NbtConstants.getTardisNavLocation(tag, NbtConstants.CURRENT_LOCATION);
+        this.targetLocation = NbtConstants.getTardisNavLocation(tag, NbtConstants.TARGET_LOCATION);
         this.fastReturnLocation = NbtConstants.getTardisNavLocation(tag, NbtConstants.RETURN_LOCATION);
 
         this.currentConsoleBlockPos = NbtUtils.readBlockPos(tag.getCompound(CURRENT_CONSOLE_POS));


### PR DESCRIPTION
Fix TARDIS setting the current location to the overworld when created in another dimension, making the TARDIS impossible to enter in survival mode (#478).

Also fixes a bug where the TARDIS would reset the current and target locations to the overworld on world reload and a bug where the dimension selector would always set the dimension to the overworld when clicked without the dimension upgrade.