### PR TITLE
Update fabric-create integration to create 6.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
-    id "dev.architectury.loom" version "1.5+" apply false
+    id "dev.architectury.loom" version "1.10+" apply false
     id "me.shedaniel.unified-publishing" version "0.1.+"
     id "com.github.breadmoirai.github-release" version "2.4.1"
 }

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 
 #### Changes
 - Amethyst Screwdriver tooltip now is colored gray.
+- Updated create-fabric integration to create 6.
 
 #### Bug Fix
 - Bug fix: TARDIS exterior disappears when moved by other mods.

--- a/fabric/src/main/java/whocraft/tardis_refined/compat/create/CreateIntergrationsFabric.java
+++ b/fabric/src/main/java/whocraft/tardis_refined/compat/create/CreateIntergrationsFabric.java
@@ -1,7 +1,8 @@
 package whocraft.tardis_refined.compat.create;
 
-import com.simibubi.create.content.redstone.displayLink.AllDisplayBehaviours;
-import com.simibubi.create.content.redstone.displayLink.DisplayBehaviour;
+import com.simibubi.create.api.behaviour.display.DisplaySource;
+import com.simibubi.create.api.registry.CreateBuiltInRegistries;
+import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
@@ -25,8 +26,8 @@ public class CreateIntergrationsFabric {
     public static void init() {
 
         // Register big data
-        DisplayBehaviour tardisOverallData = AllDisplayBehaviours.register(new ResourceLocation(TardisRefined.MODID, "tardis_bigdata"), new TardisDisplaySource());
-        AllDisplayBehaviours.assignBlockEntity(tardisOverallData, FLIGHT_DETECTOR.get());
+        DisplaySource tardisOverallData = Registry.register(CreateBuiltInRegistries.DISPLAY_SOURCE, new ResourceLocation(TardisRefined.MODID, "tardis_bigdata"), new TardisDisplaySource());
+        DisplaySource.BY_BLOCK_ENTITY.add(FLIGHT_DETECTOR.get(), tardisOverallData);
 
 
         // Fuel
@@ -100,11 +101,13 @@ public class CreateIntergrationsFabric {
 
         //Register all
         for (QuickOneLineDisplaySource.TardisInfo tardisInfo : tardisInfos) {
-            AllDisplayBehaviours.assignBlockEntity(AllDisplayBehaviours.register(tardisInfo.getId(), new QuickOneLineDisplaySource(tardisInfo)), FLIGHT_DETECTOR.get());
+            var s = Registry.register(CreateBuiltInRegistries.DISPLAY_SOURCE, tardisInfo.getId(), new QuickOneLineDisplaySource(tardisInfo));
+            DisplaySource.BY_BLOCK_ENTITY.add(FLIGHT_DETECTOR.get(), s);
         }
 
         for (TardisNavLocationDisplaySource.TardisNavInfo tardisInfo : tardisNavInfos) {
-            AllDisplayBehaviours.assignBlockEntity(AllDisplayBehaviours.register(tardisInfo.getId(), new TardisNavLocationDisplaySource(tardisInfo)), FLIGHT_DETECTOR.get());
+            var s = Registry.register(CreateBuiltInRegistries.DISPLAY_SOURCE, tardisInfo.getId(), new TardisNavLocationDisplaySource(tardisInfo));
+            DisplaySource.BY_BLOCK_ENTITY.add(FLIGHT_DETECTOR.get(), s);
         }
 
     }

--- a/fabric/src/main/java/whocraft/tardis_refined/compat/create/TardisDisplaySource.java
+++ b/fabric/src/main/java/whocraft/tardis_refined/compat/create/TardisDisplaySource.java
@@ -1,7 +1,7 @@
 package whocraft.tardis_refined.compat.create;
 
+import com.simibubi.create.api.behaviour.display.DisplaySource;
 import com.simibubi.create.content.redstone.displayLink.DisplayLinkContext;
-import com.simibubi.create.content.redstone.displayLink.source.DisplaySource;
 import com.simibubi.create.content.redstone.displayLink.target.DisplayTargetStats;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;

--- a/fabric/src/main/java/whocraft/tardis_refined/compat/create/TardisNavLocationDisplaySource.java
+++ b/fabric/src/main/java/whocraft/tardis_refined/compat/create/TardisNavLocationDisplaySource.java
@@ -1,7 +1,7 @@
 package whocraft.tardis_refined.compat.create;
 
+import com.simibubi.create.api.behaviour.display.DisplaySource;
 import com.simibubi.create.content.redstone.displayLink.DisplayLinkContext;
-import com.simibubi.create.content.redstone.displayLink.source.DisplaySource;
 import com.simibubi.create.content.redstone.displayLink.target.DisplayTargetStats;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;

--- a/gradle.properties
+++ b/gradle.properties
@@ -88,11 +88,11 @@ sodium_version=mc1.20.1-0.5.8
 #Mod versions
 registrate_version_forge = MC1.20-1.3.11
 registrate_version_fabric = 1.3.62-MC1.20.1
-create_version_forge = 6.0.4-79
+create_version_forge = 6.0.7-287
 ponder_version = 1.0.52
 flywheel_version = 1.0.2
-create_version_fabric = 0.5.1-f-build.1376+mc1.20.1
-create_version_plain = 0.5.1.f
+create_version_fabric = 6.0.7.0+mc1.20.1-build.1716
+create_version_plain = 6.0.7.0
 flywheel_version_fabric = 0.6.10-2
 flywheel_version_forge = 0.6.10-8
 flywheel_minecraft_version=1.20.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request makes the Fabric version of TardisRefined work with Create 6, breaking compatibility with Create 0.5.

Also updates Loom and Gradle since it won't build otherwise (Create seems to use Loom 1.10 now).

I should note that there are still some create addons which have not yet updated to Create 6. One notable example is [Create: Interactive](https://modrinth.com/mod/interactive), but it doesn't support Create 6 on forge either. There are some create addons that support Create 6 on Forge but not on Fabric, such as [Create Jetpack](https://modrinth.com/mod/create-jetpack), but I don't know if it makes sense to wait for them to update their Fabric versions. With that said, [Clockwork](https://modrinth.com/mod/create-clockwork) does support Create 6. I'm primarily mentioning this since TardisRefined currently is in the unique position of supporting both Create 0.5 and Create 6 at once in a weird way, which this patch would put an end to. Although to be honest it would probably make more sense to add a config option to disable create compatibility entirely instead.