### PR TITLE
Improve Valkyrien Skies and Immersive Portals compatibility

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,11 @@
 #### Changes
 - Amethyst Screwdriver tooltip now is colored gray.
 
+#### Configs
+- New config option to disable teleportation for the Immersive Portals portal, instead teleporting the player directly as if Immersive Portals integration was disabled.
+- New config option to toggle the above setting separately when the door is on a Valkyrien Skies ship.
+- New config option to disable the collision box of the door while open with Immersive Portals integration enabled on Valkyrien Skies ships.
+
 #### Bug Fix
 - Bug fix: TARDIS exterior disappears when moved by other mods.
 - Bug fix: Taking off or landing a TARDIS on a Valkyrien Skies ship breaks the ship.
@@ -18,6 +23,7 @@
 - Bug fix: TARDIS does not take Valkyrien Skies ships into account when computing travel distance.
 - Bug fix: TARDIS does not automatically try to land on ships.
 - Bug fix: Flickering when spectating TARDIS exterior on a Valkyrien Skies ship.
+- Bug fix: Immersive Portals portal is not rotated correctly when door is on a Valkyrien Skies ship.
 
 - Bug fix: Fixes Console Textures having left over prefabs
 - Bug fix: Fixes Forge not having the same access level as Fabric (https://github.com/WhoCraft/TardisRefined/issues/477)
@@ -25,4 +31,5 @@
 - Bug fix: Fixed the TARDIS forgetting its current dimension on world reload
 - Bug fix: Fix materialize around upgrade not working.
 - Bug fix: Fixed TARDIS being broken when created in a non-overworld dimension.
+- Bug fix: Immersive Portals portal sometimes not spawning when opened from exterior.
 

--- a/common/src/main/java/whocraft/tardis_refined/TRConfig.java
+++ b/common/src/main/java/whocraft/tardis_refined/TRConfig.java
@@ -66,11 +66,29 @@ public class TRConfig {
         public final ForgeConfigSpec.ConfigValue<List<? extends String>> ADVENTURE_MODE_DEFAULTS;
         public final ForgeConfigSpec.BooleanValue ADVENTURE_MODE;
 
+        public final ForgeConfigSpec.EnumValue<IPTeleportationMode> IP_TELEPORTATION;
+        public final ForgeConfigSpec.EnumValue<IPTeleportationMode> IP_TELEPORTATION_VS;
+
+        public enum IPTeleportationMode {
+            PORTAL,
+            ITP;
+
+            private static final String COMMENT = "PORTAL is the normal immersive portals with maximum smoothness. ITP instead teleports the player directly similar to when Immersive Portals integration is disabled, making the boti effect purely visual.";
+        }
+
         public Server(ForgeConfigSpec.Builder builder) {
             builder.push("travel");
             BANNED_DIMENSIONS = builder.translation("config.tardis_refined.banned_dimensions").comment("A list of Dimensions the TARDIS cannot land in.").defineList("banned_dimensions", Lists.newArrayList("example:dimension"), String.class::isInstance);
             ADVENTURE_MODE_DEFAULTS = builder.translation("config.tardis_refined.adventure_mode_defaults").comment("A list of Dimensions that are automatically sampled").defineList("adventure_mode_defaults", Lists.newArrayList("minecraft:overworld"), String.class::isInstance);
             ADVENTURE_MODE = builder.translation("config.tardis_refined.adventure_mode").comment("Toggles whether players must discover and sample dimensions before they can travel there").define("adventure_mode", false);
+            builder.pop();
+            builder.push("compatibility");
+            builder.push("immersive_portals");
+            IP_TELEPORTATION = builder.comment("Choose what teleportation method to use when walking through the TARDIS door. " + IPTeleportationMode.COMMENT).translation(ModMessages.CONFIG_IP_TELEPORTATION).defineEnum("teleportation_mode", IPTeleportationMode.PORTAL);
+            builder.pop();
+            builder.push("immersive_portals_valkyrien_skies");
+            IP_TELEPORTATION_VS = builder.comment("Choose what teleportation method to use when walking through the TARDIS door on a Valkyrien Skies ship. " + IPTeleportationMode.COMMENT + " ITP is recommended to avoid getting stuck in walls/the void when the ship is moving.").translation(ModMessages.CONFIG_IP_TELEPORTATION_VS).defineEnum("teleportation_mode", IPTeleportationMode.ITP);
+            builder.pop();
             builder.pop();
         }
 

--- a/common/src/main/java/whocraft/tardis_refined/TRConfig.java
+++ b/common/src/main/java/whocraft/tardis_refined/TRConfig.java
@@ -53,9 +53,14 @@ public class TRConfig {
     public static class Common {
         public final ForgeConfigSpec.BooleanValue COMPATIBILITY_IP;
 
+        public final ForgeConfigSpec.BooleanValue IP_VS_COLLISION;
+
         public Common(ForgeConfigSpec.Builder builder) {
             builder.push("compatibility");
             COMPATIBILITY_IP = builder.comment("Toggle Immersive Portals compatibility (TR 2.0+). 2.0 has limited support").translation(ModMessages.CONFIG_IP_COMPAT).define("immersive_portals_support", true);
+            builder.push("immersive_portals_valkyrien_skies");
+            IP_VS_COLLISION = builder.comment("If false, the TARDIS door's collision box will be disabled when opened on a Valkyrien Skies ship if teleportation_mode_vs is set to PORTAL.").translation(ModMessages.CONFIG_IP_VS_COLLISION).define("open_door_ship_collision", true);
+            builder.pop();
             builder.pop();
         }
 
@@ -87,7 +92,7 @@ public class TRConfig {
             IP_TELEPORTATION = builder.comment("Choose what teleportation method to use when walking through the TARDIS door. " + IPTeleportationMode.COMMENT).translation(ModMessages.CONFIG_IP_TELEPORTATION).defineEnum("teleportation_mode", IPTeleportationMode.PORTAL);
             builder.pop();
             builder.push("immersive_portals_valkyrien_skies");
-            IP_TELEPORTATION_VS = builder.comment("Choose what teleportation method to use when walking through the TARDIS door on a Valkyrien Skies ship. " + IPTeleportationMode.COMMENT + " ITP is recommended to avoid getting stuck in walls/the void when the ship is moving.").translation(ModMessages.CONFIG_IP_TELEPORTATION_VS).defineEnum("teleportation_mode", IPTeleportationMode.ITP);
+            IP_TELEPORTATION_VS = builder.comment("Choose what teleportation method to use when walking through the TARDIS door on a Valkyrien Skies ship. " + IPTeleportationMode.COMMENT + " ITP is recommended to avoid getting stuck in walls/the void when the ship is moving.").translation(ModMessages.CONFIG_IP_TELEPORTATION_VS).defineEnum("teleportation_mode_vs", IPTeleportationMode.ITP);
             builder.pop();
             builder.pop();
         }

--- a/common/src/main/java/whocraft/tardis_refined/common/block/door/GlobalDoorBlock.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/block/door/GlobalDoorBlock.java
@@ -106,7 +106,7 @@ public class GlobalDoorBlock extends InternalDoorBlock {
 
     @Override
     public VoxelShape getCollisionShape(BlockState blockState, BlockGetter blockGetter, BlockPos blockPos, CollisionContext collisionContext) {
-        var blockEntity = blockGetter.getBlockEntity(blockPos);
+        BlockEntity blockEntity = blockGetter.getBlockEntity(blockPos);
         //noinspection ConstantValue IntelliJ got confused by this for some reason...
         if (
                 !TRConfig.COMMON.IP_VS_COLLISION.get() && blockEntity != null && blockEntity.getLevel() != null &&

--- a/common/src/main/java/whocraft/tardis_refined/common/block/door/GlobalDoorBlock.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/block/door/GlobalDoorBlock.java
@@ -17,13 +17,18 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import whocraft.tardis_refined.TRConfig;
 import whocraft.tardis_refined.common.blockentity.door.GlobalDoorBlockEntity;
 import whocraft.tardis_refined.common.blockentity.life.EyeBlockEntity;
 import whocraft.tardis_refined.common.capability.tardis.TardisLevelOperator;
 import whocraft.tardis_refined.common.tardis.manager.AestheticHandler;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.portals.ImmersivePortals;
+import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 
 public class GlobalDoorBlock extends InternalDoorBlock {
 
@@ -101,6 +106,15 @@ public class GlobalDoorBlock extends InternalDoorBlock {
 
     @Override
     public VoxelShape getCollisionShape(BlockState blockState, BlockGetter blockGetter, BlockPos blockPos, CollisionContext collisionContext) {
+        var blockEntity = blockGetter.getBlockEntity(blockPos);
+        //noinspection ConstantValue IntelliJ got confused by this for some reason...
+        if (
+                !TRConfig.COMMON.IP_VS_COLLISION.get() && blockEntity != null && blockEntity.getLevel() != null &&
+                ModCompatChecker.immersivePortals() && ImmersivePortals.isTeleportingPortalPresent(blockEntity.getLevel().dimension()) &&
+                ModCompatChecker.valkyrienSkies() && VSHelper.isBlockInShipyard(blockEntity.getLevel(), blockPos)
+        ) {
+            return Shapes.empty();
+        }
         return this.getShape(blockState, blockGetter, blockPos, collisionContext);
     }
 

--- a/common/src/main/java/whocraft/tardis_refined/common/block/door/InternalDoorBlock.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/block/door/InternalDoorBlock.java
@@ -120,7 +120,9 @@ public class InternalDoorBlock extends BaseEntityBlock {
 
                 TardisLevelOperator.get(serverLevel).ifPresent(tardisLevelOperator -> {
                     if (!tardisLevelOperator.getPilotingManager().isInFlight()) {
-                        AABB teleportAABB = this.getCollisionShape(blockState, level, blockPos, CollisionContext.of(entity)).bounds().move(blockPos);
+                        var teleportShape = this.getCollisionShape(blockState, level, blockPos, CollisionContext.of(entity));
+                        if (teleportShape.isEmpty()) return;
+                        AABB teleportAABB = teleportShape.bounds().move(blockPos);
                         if (TRTeleporter.teleportIfCollided(serverLevel, blockPos, entity, teleportAABB)) {
                             door.onAttemptEnter(blockState, serverLevel, blockPos, entity);
                         }

--- a/common/src/main/java/whocraft/tardis_refined/common/block/door/InternalDoorBlock.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/block/door/InternalDoorBlock.java
@@ -120,7 +120,7 @@ public class InternalDoorBlock extends BaseEntityBlock {
 
                 TardisLevelOperator.get(serverLevel).ifPresent(tardisLevelOperator -> {
                     if (!tardisLevelOperator.getPilotingManager().isInFlight()) {
-                        var teleportShape = this.getCollisionShape(blockState, level, blockPos, CollisionContext.of(entity));
+                        VoxelShape teleportShape = this.getCollisionShape(blockState, level, blockPos, CollisionContext.of(entity));
                         if (teleportShape.isEmpty()) return;
                         AABB teleportAABB = teleportShape.bounds().move(blockPos);
                         if (TRTeleporter.teleportIfCollided(serverLevel, blockPos, entity, teleportAABB)) {

--- a/common/src/main/java/whocraft/tardis_refined/common/block/shell/GlobalShellBlock.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/block/shell/GlobalShellBlock.java
@@ -23,6 +23,7 @@ import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import whocraft.tardis_refined.TRConfig;
 import whocraft.tardis_refined.common.blockentity.shell.GlobalShellBlockEntity;
 import whocraft.tardis_refined.common.blockentity.shell.ShellBaseBlockEntity;
 import whocraft.tardis_refined.common.tardis.themes.ShellTheme;
@@ -56,14 +57,16 @@ public class GlobalShellBlock extends ShellBaseBlock {
     @Override
     public VoxelShape getCollisionShape(BlockState blockState, BlockGetter blockGetter, BlockPos blockPos, CollisionContext collisionContext) {
         if (blockGetter.getBlockEntity(blockPos) instanceof GlobalShellBlockEntity shellBlockEntity) {
-            if (shellBlockEntity.theme() == ShellTheme.BRIEFCASE.getId())
-                return BRIEFCASE_COLLISION_SHAPE;
+            //noinspection ConstantValue IntelliJ got confused by this for some reason...
             if (
+                    !TRConfig.COMMON.IP_VS_COLLISION.get() &&
                     ModCompatChecker.immersivePortals() && ImmersivePortals.isTeleportingPortalPresent(shellBlockEntity.getTardisId()) &&
                     ModCompatChecker.valkyrienSkies() && VSHelper.isBlockInShipyard(shellBlockEntity.getLevel(), blockPos)
             ) {
                 return Shapes.empty();
             }
+            if (shellBlockEntity.theme() == ShellTheme.BRIEFCASE.getId())
+                return BRIEFCASE_COLLISION_SHAPE;
         }
         return super.getCollisionShape(blockState, blockGetter, blockPos, collisionContext);
     }

--- a/common/src/main/java/whocraft/tardis_refined/common/block/shell/GlobalShellBlock.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/block/shell/GlobalShellBlock.java
@@ -59,8 +59,7 @@ public class GlobalShellBlock extends ShellBaseBlock {
             if (shellBlockEntity.theme() == ShellTheme.BRIEFCASE.getId())
                 return BRIEFCASE_COLLISION_SHAPE;
             if (
-                    shellBlockEntity.isOpen() &&
-                    ModCompatChecker.immersivePortals() && ImmersivePortals.doPortalsExistForTardis(ImmersivePortals.getUUIDForTARDIS(shellBlockEntity.getTardisId())) &&
+                    ModCompatChecker.immersivePortals() && ImmersivePortals.isTeleportingPortalPresent(shellBlockEntity.getTardisId()) &&
                     ModCompatChecker.valkyrienSkies() && VSHelper.isBlockInShipyard(shellBlockEntity.getLevel(), blockPos)
             ) {
                 return Shapes.empty();

--- a/common/src/main/java/whocraft/tardis_refined/common/block/shell/GlobalShellBlock.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/block/shell/GlobalShellBlock.java
@@ -19,12 +19,16 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import whocraft.tardis_refined.common.blockentity.shell.GlobalShellBlockEntity;
 import whocraft.tardis_refined.common.blockentity.shell.ShellBaseBlockEntity;
 import whocraft.tardis_refined.common.tardis.themes.ShellTheme;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.portals.ImmersivePortals;
+import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 
 public class GlobalShellBlock extends ShellBaseBlock {
 
@@ -54,6 +58,13 @@ public class GlobalShellBlock extends ShellBaseBlock {
         if (blockGetter.getBlockEntity(blockPos) instanceof GlobalShellBlockEntity shellBlockEntity) {
             if (shellBlockEntity.theme() == ShellTheme.BRIEFCASE.getId())
                 return BRIEFCASE_COLLISION_SHAPE;
+            if (
+                    shellBlockEntity.isOpen() &&
+                    ModCompatChecker.immersivePortals() && ImmersivePortals.doPortalsExistForTardis(ImmersivePortals.getUUIDForTARDIS(shellBlockEntity.getTardisId())) &&
+                    ModCompatChecker.valkyrienSkies() && VSHelper.isBlockInShipyard(shellBlockEntity.getLevel(), blockPos)
+            ) {
+                return Shapes.empty();
+            }
         }
         return super.getCollisionShape(blockState, blockGetter, blockPos, collisionContext);
     }

--- a/common/src/main/java/whocraft/tardis_refined/common/block/shell/ShellBaseBlock.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/block/shell/ShellBaseBlock.java
@@ -121,7 +121,9 @@ public abstract class ShellBaseBlock extends BaseEntityBlock implements SimpleWa
         if (!level.isClientSide()) {
             ServerLevel serverLevel = (ServerLevel) level;
             if (serverLevel.getBlockEntity(blockPos) instanceof ExteriorShell shellEntity) {
-                AABB teleportAABB = this.getCollisionShape(blockState, level, blockPos, CollisionContext.of(entity)).bounds().move(blockPos);
+                var teleportShape = this.getCollisionShape(blockState, level, blockPos, CollisionContext.of(entity));
+                if (teleportShape.isEmpty()) return;
+                AABB teleportAABB = teleportShape.bounds().move(blockPos);
                 if (TRTeleporter.teleportIfCollided(serverLevel, blockPos, entity, teleportAABB)) {
                     shellEntity.onAttemptEnter(blockState, serverLevel, blockPos, entity);
                 }

--- a/common/src/main/java/whocraft/tardis_refined/common/block/shell/ShellBaseBlock.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/block/shell/ShellBaseBlock.java
@@ -121,7 +121,7 @@ public abstract class ShellBaseBlock extends BaseEntityBlock implements SimpleWa
         if (!level.isClientSide()) {
             ServerLevel serverLevel = (ServerLevel) level;
             if (serverLevel.getBlockEntity(blockPos) instanceof ExteriorShell shellEntity) {
-                var teleportShape = this.getCollisionShape(blockState, level, blockPos, CollisionContext.of(entity));
+                VoxelShape teleportShape = this.getCollisionShape(blockState, level, blockPos, CollisionContext.of(entity));
                 if (teleportShape.isEmpty()) return;
                 AABB teleportAABB = teleportShape.bounds().move(blockPos);
                 if (TRTeleporter.teleportIfCollided(serverLevel, blockPos, entity, teleportAABB)) {

--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/door/GlobalDoorBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/door/GlobalDoorBlockEntity.java
@@ -17,6 +17,9 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 import whocraft.tardis_refined.common.capability.tardis.TardisLevelOperator;
 import whocraft.tardis_refined.common.tardis.themes.ShellTheme;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.portals.ImmersivePortals;
+import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 import whocraft.tardis_refined.constants.NbtConstants;
 import whocraft.tardis_refined.patterns.ShellPattern;
 import whocraft.tardis_refined.patterns.ShellPatterns;
@@ -172,6 +175,14 @@ public class GlobalDoorBlockEntity extends InternalDoorBlockEntity implements Bl
 
     @Override
     public void tick(Level level, BlockPos blockPos, BlockState blockState, InternalDoorBlockEntity blockEntity) {
+        //noinspection ConstantValue IntelliJ got confused by this for some reason...
+        if (
+                !level.isClientSide() && level instanceof ServerLevel sl &&
+                ModCompatChecker.valkyrienSkies() && VSHelper.isBlockInShipyard(level, blockPos) &&
+                ModCompatChecker.immersivePortals() && ImmersivePortals.doPortalsExistForTardis(level.dimension())
+        ) {
+            TardisLevelOperator.get(sl).ifPresent(ImmersivePortals::updatePortalPositions);
+        }
   /*      if (level instanceof ServerLevel serverLevel) {
             TardisLevelOperator.get(serverLevel).ifPresent(tardisLevelOperator -> {
                 if (blockEntity.isOpen() && tardisLevelOperator.getPilotingManager().isInFlight()) {

--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/GlobalShellBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/GlobalShellBlockEntity.java
@@ -23,7 +23,11 @@ import whocraft.tardis_refined.common.tardis.manager.AestheticHandler;
 import whocraft.tardis_refined.common.tardis.manager.TardisExteriorManager;
 import whocraft.tardis_refined.common.tardis.manager.TardisPilotingManager;
 import whocraft.tardis_refined.common.tardis.themes.ShellTheme;
+import whocraft.tardis_refined.common.util.DimensionUtil;
 import whocraft.tardis_refined.common.util.PlayerUtil;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.portals.ImmersivePortals;
+import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 import whocraft.tardis_refined.constants.ModMessages;
 import whocraft.tardis_refined.constants.NbtConstants;
 import whocraft.tardis_refined.patterns.ShellPattern;
@@ -71,6 +75,19 @@ public class GlobalShellBlockEntity extends ShellBaseBlockEntity {
         this.setChanged();
         this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), Block.UPDATE_ALL);
         return this;
+    }
+
+    @Override
+    public void tick(Level level, BlockPos blockPos, BlockState blockState, ShellBaseBlockEntity blockEntity) {
+        super.tick(level, blockPos, blockState, blockEntity);
+	    //noinspection ConstantValue IntelliJ got confused by this for some reason...
+	    if (
+                !level.isClientSide() &&
+                ModCompatChecker.valkyrienSkies() && VSHelper.isBlockInShipyard(level, blockPos) &&
+                ModCompatChecker.immersivePortals() && ImmersivePortals.doPortalsExistForTardis(ImmersivePortals.getUUIDForTARDIS(TARDIS_ID))
+        ) {
+            TardisLevelOperator.get(DimensionUtil.getLevel(blockEntity.TARDIS_ID)).ifPresent(ImmersivePortals::updatePortalPositions);
+        }
     }
 
     @Override

--- a/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/blockentity/shell/ShellBaseBlockEntity.java
@@ -38,7 +38,8 @@ import whocraft.tardis_refined.constants.ModMessages;
 import whocraft.tardis_refined.constants.NbtConstants;
 import whocraft.tardis_refined.registry.TRUpgrades;
 
-import java.util.UUID;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class ShellBaseBlockEntity extends BlockEntity implements ExteriorShell, BlockEntityTicker<ShellBaseBlockEntity> {
 
@@ -143,7 +144,7 @@ public abstract class ShellBaseBlockEntity extends BlockEntity implements Exteri
                         ResourceLocation theme = aesthetics.getShellTheme();
 
                         if (ModCompatChecker.immersivePortals()) {
-                            if (ImmersivePortals.isShellThemeSupported(theme) && ImmersivePortals.doPortalsExistForTardis(UUID.fromString(TARDIS_ID.location().getPath()))) {
+                            if (ImmersivePortals.isShellThemeSupported(theme) && ImmersivePortals.isTeleportingPortalPresent(TARDIS_ID)) {
                                 return;
                             }
                         }

--- a/common/src/main/java/whocraft/tardis_refined/common/capability/tardis/TardisLevelOperator.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/capability/tardis/TardisLevelOperator.java
@@ -48,7 +48,6 @@ import whocraft.tardis_refined.registry.TRDimensionTypes;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Optional;
-import java.util.UUID;
 
 import static whocraft.tardis_refined.common.block.shell.ShellBaseBlock.REGEN;
 
@@ -304,7 +303,7 @@ public class TardisLevelOperator {
         if (aestheticHandler.getShellTheme() != null) {
             ResourceLocation theme = aestheticHandler.getShellTheme();
             if (ModCompatChecker.immersivePortals() && !(this.internalDoor instanceof RootShellDoorBlockEntity)) {
-                if (!ignoreDoor && level.dimensionTypeId() == TRDimensionTypes.TARDIS && ImmersivePortals.isShellThemeSupported(theme) && ImmersivePortals.doPortalsExistForTardis(UUID.fromString(doorLevel.dimension().location().getPath()))) {
+                if (!ignoreDoor && level.dimensionTypeId() == TRDimensionTypes.TARDIS && ImmersivePortals.isShellThemeSupported(theme) && ImmersivePortals.isTeleportingPortalPresent(doorLevel.dimension())) {
                     return false;
                 }
             }

--- a/common/src/main/java/whocraft/tardis_refined/common/util/TRTeleporter.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/util/TRTeleporter.java
@@ -3,10 +3,7 @@ package whocraft.tardis_refined.common.util;
 import com.google.common.base.Preconditions;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;
-import net.minecraft.network.protocol.game.ClientboundChangeDifficultyPacket;
-import net.minecraft.network.protocol.game.ClientboundPlayerAbilitiesPacket;
-import net.minecraft.network.protocol.game.ClientboundSetExperiencePacket;
-import net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket;
+import net.minecraft.network.protocol.game.*;
 import net.minecraft.server.TickTask;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -16,6 +13,7 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.RelativeMovement;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
@@ -96,6 +94,14 @@ public class TRTeleporter {
             pEntity.setYRot(updatedYRot); //Set the desired yRot and xRot before teleportation. For non-players, this means the facing is copied over to the copy of the entity which we recreate. For players, it should update the rotation with the correct facing at the destination
             pEntity.setXRot(updatedXRot);
             ImmersivePortals.teleportViaIp(pEntity, destination, pX, pY, pZ);
+            // The rotation won't be set properly unless we set it afterward.
+            if (pEntity instanceof ServerPlayer player) {
+                player.connection.teleport(
+                        player.getX(), player.getY(), player.getZ(),
+                        updatedYRot, updatedXRot,
+                        Set.of(RelativeMovement.X, RelativeMovement.Y, RelativeMovement.Z)
+                );
+            }
             return true;
         }
 

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/BotiPortalEntity.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/BotiPortalEntity.java
@@ -8,6 +8,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
 import qouteall.imm_ptl.core.portal.Portal;
+import qouteall.imm_ptl.core.portal.animation.TimingFunction;
 import whocraft.tardis_refined.common.tardis.themes.ShellTheme;
 import whocraft.tardis_refined.constants.NbtConstants;
 
@@ -25,6 +26,8 @@ public class BotiPortalEntity extends Portal {
 
     public BotiPortalEntity(EntityType<?> entityType, Level world) {
         super(entityType, world);
+        this.animation.defaultAnimation.durationTicks = 1;
+        this.animation.defaultAnimation.timingFunction = TimingFunction.linear;
     }
 
     public ShellTheme getShellTheme() {

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
@@ -26,6 +26,7 @@ import qouteall.imm_ptl.core.portal.PortalManipulation;
 import qouteall.q_misc_util.MiscHelper;
 import qouteall.q_misc_util.api.DimensionAPI;
 import qouteall.q_misc_util.my_util.DQuaternion;
+import whocraft.tardis_refined.TRConfig;
 import whocraft.tardis_refined.api.event.EventResult;
 import whocraft.tardis_refined.api.event.TardisCommonEvents;
 import whocraft.tardis_refined.common.blockentity.door.TardisInternalDoor;
@@ -74,6 +75,23 @@ public class ImmersivePortals {
 
     public static boolean doPortalsExistForTardis(UUID uuid) {
         return EXISTING_PORTALS.containsKey(uuid);
+    }
+
+    public static boolean isTeleportingPortalPresent(ResourceKey<Level> dim) {
+        try {
+            return isTeleportingPortalPresent(getUUIDForTARDIS(dim));
+        } catch (IllegalArgumentException ignored) { // Thrown when not a valid UUID.
+            return false;
+        }
+    }
+
+    public static boolean isTeleportingPortalPresent(UUID uuid) {
+        if (doPortalsExistForTardis(uuid)) {
+            var portal = getPortalsForTardis(uuid);
+            return portal.getInternalPortal().teleportable && portal.getShellPortal().teleportable;
+        } else {
+            return false;
+        }
     }
 
     public static PortalEntry getPortalsForTardis(UUID uuid) {
@@ -274,13 +292,14 @@ public class ImmersivePortals {
         return true;
     }
 
-    public record PositionHolder(Vec3 pos, Vec3 axisW, Vec3 axisH) {
+    public record PositionHolder(Vec3 pos, Vec3 axisW, Vec3 axisH, boolean airship) {
         public DQuaternion getQuaternion() {
             return DQuaternion.fromFacingVecs(axisW, axisH);
         }
     }
 
     private static PositionHolder getPortalPosition(Level level, BlockPos blockPos, Direction direction, Vec3 doorPos) {
+        boolean airship = false;
         Vec3 axisW = Vec3.atLowerCornerOf(direction.getCounterClockWise().getNormal());
 
         Vec3 axisH = Vec3.atLowerCornerOf(Direction.UP.getNormal());
@@ -289,8 +308,9 @@ public class ImmersivePortals {
             axisW = VSHelper.toWorldRotation(level, blockPos, axisW);
             axisH = VSHelper.toWorldRotation(level, blockPos, axisH);
             doorPos = VSHelper.toWorldPosition(level, blockPos, doorPos);
+            airship = VSHelper.isBlockOnShip(level, blockPos);
         }
-        return new PositionHolder(doorPos, axisW, axisH);
+        return new PositionHolder(doorPos, axisW, axisH, airship);
     }
 
     private static Vec3 getPortalPosForBlockPos(BlockPos pos, Direction direction, PortalOffets.OffsetData offset) {
@@ -382,6 +402,12 @@ public class ImmersivePortals {
         }
     }
 
+    private static void setAllowTeleportation(BotiPortalEntity portal, boolean isOnAirship) {
+        if ((isOnAirship ? TRConfig.SERVER.IP_TELEPORTATION_VS.get() : TRConfig.SERVER.IP_TELEPORTATION.get()) != TRConfig.Server.IPTeleportationMode.PORTAL) {
+            portal.setTeleportable(false);
+        }
+    }
+
     public static void createPortals(TardisLevelOperator operator) {
 
         if(operator.getPilotingManager().isInFlight()){
@@ -441,6 +467,7 @@ public class ImmersivePortals {
         var interior = getPortalPosition(operatorLevel, door.getDoorPosition(), door.getTeleportRotation(), entryPosition);
         exteriorEntryPosition = ext.pos;
         entryPosition = interior.pos;
+        boolean airship = ext.airship || interior.airship;
 
         var extQuat = ext.getQuaternion();
         var interiorQuat = interior.getQuaternion();
@@ -458,6 +485,8 @@ public class ImmersivePortals {
         interiorPortal.setInteractable(false);
         interiorPortal.setValid(true);
         exteriorPortal.setValid(true);
+        setAllowTeleportation(exteriorPortal, airship);
+        setAllowTeleportation(interiorPortal, airship);
 
         CompoundTag tag = new CompoundTag();
         tag.putBoolean("adjustPositionAfterTeleport", false);

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
@@ -1,6 +1,7 @@
 package whocraft.tardis_refined.compat.portals;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceKey;
@@ -11,6 +12,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -27,6 +29,7 @@ import qouteall.q_misc_util.my_util.DQuaternion;
 import whocraft.tardis_refined.api.event.EventResult;
 import whocraft.tardis_refined.api.event.TardisCommonEvents;
 import whocraft.tardis_refined.common.blockentity.door.TardisInternalDoor;
+import whocraft.tardis_refined.common.blockentity.shell.ExteriorShell;
 import whocraft.tardis_refined.common.capability.tardis.TardisLevelOperator;
 import whocraft.tardis_refined.common.dimension.DimensionHandler;
 import whocraft.tardis_refined.common.tardis.TardisNavLocation;
@@ -36,6 +39,7 @@ import whocraft.tardis_refined.common.tardis.manager.TardisPilotingManager;
 import whocraft.tardis_refined.common.tardis.themes.ShellTheme;
 import whocraft.tardis_refined.common.util.Platform;
 import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 import whocraft.tardis_refined.registry.RegistrySupplier;
 import whocraft.tardis_refined.registry.TRDimensionTypes;
 
@@ -60,6 +64,14 @@ public class ImmersivePortals {
         EXISTING_PORTALS.clear();
     }
 
+    public static boolean doPortalsExistForTardis(ResourceKey<Level> dim) {
+        try {
+            return doPortalsExistForTardis(getUUIDForTARDIS(dim));
+        } catch (IllegalArgumentException ignored) { // Thrown when not a valid UUID.
+            return false;
+        }
+    }
+
     public static boolean doPortalsExistForTardis(UUID uuid) {
         return EXISTING_PORTALS.containsKey(uuid);
     }
@@ -68,6 +80,9 @@ public class ImmersivePortals {
         return EXISTING_PORTALS.get(uuid);
     }
 
+    public static UUID getUUIDForTARDIS(ResourceKey<Level> tardisID) {
+        return UUID.fromString(tardisID.location().getPath());
+    }
 
     public static ServerLevel createDimension(Level level, ResourceKey<Level> id) {
         MinecraftServer server = MiscHelper.getServer();
@@ -259,6 +274,114 @@ public class ImmersivePortals {
         return true;
     }
 
+    public record PositionHolder(Vec3 pos, Vec3 axisW, Vec3 axisH) {
+        public DQuaternion getQuaternion() {
+            return DQuaternion.fromFacingVecs(axisW, axisH);
+        }
+    }
+
+    private static PositionHolder getPortalPosition(Level level, BlockPos blockPos, Direction direction, Vec3 doorPos) {
+        Vec3 axisW = Vec3.atLowerCornerOf(direction.getCounterClockWise().getNormal());
+
+        Vec3 axisH = Vec3.atLowerCornerOf(Direction.UP.getNormal());
+
+        if (ModCompatChecker.valkyrienSkies()) {
+            axisW = VSHelper.toWorldRotation(level, blockPos, axisW);
+            axisH = VSHelper.toWorldRotation(level, blockPos, axisH);
+            doorPos = VSHelper.toWorldPosition(level, blockPos, doorPos);
+        }
+        return new PositionHolder(doorPos, axisW, axisH);
+    }
+
+    private static Vec3 getPortalPosForBlockPos(BlockPos pos, Direction direction, PortalOffets.OffsetData offset) {
+        var returnPos = new Vec3(pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5);
+
+        return switch (direction) {
+            case EAST -> returnPos.add(offset.east());
+            case SOUTH -> returnPos.add(offset.south());
+            case WEST -> returnPos.add(offset.west());
+            case NORTH -> returnPos.add(offset.north());
+            default -> throw new IllegalArgumentException("Why is the TARDIS facing up/down?");
+        };
+    }
+
+    private static boolean updatePortalPosition(PositionHolder position, BotiPortalEntity portal, BotiPortalEntity otherPortal) {
+        boolean updated = false;
+        if (!portal.axisH.equals(position.axisH) || !portal.axisW.equals(position.axisW)) {
+            portal.setOrientation(position.axisW, position.axisH);
+            PortalManipulation.adjustRotationToConnect(portal, otherPortal);
+            updated = true;
+        }
+        if (!portal.getOriginPos().equals(position.pos)) {
+            portal.setOriginPos(position.pos);
+            updated = true;
+        }
+        if (!otherPortal.getDestPos().equals(position.pos)) {
+            otherPortal.setDestination(position.pos);
+            updated = true;
+        }
+
+        return updated;
+    }
+
+    private static <T extends Entity> T reloadEntityIfLoaded(T entity) {
+        // Portal will get unloaded at some point.
+        // If we notice that, and the chunk where it's supposed to be is loaded, we try getting that one instead.
+        if (
+                entity.isRemoved() && entity.level() instanceof ServerLevel sl &&
+                sl.areEntitiesLoaded(ChunkPos.asLong(entity.blockPosition()))
+        ) {
+            var newEntity = sl.getEntity(entity.getUUID());
+            if (newEntity != null && newEntity.getClass() == entity.getClass()) {
+                //noinspection unchecked
+                return (T) newEntity;
+            }
+        }
+        return entity;
+    }
+
+    public static void updatePortalPositions(TardisLevelOperator operator) {
+        ResourceLocation theme = operator.getAestheticHandler().getShellTheme();
+
+        if (!isShellThemeSupported(theme)) {
+            destroyPortals(operator);
+            return;
+        }
+        PortalOffets themeData = THEME_OFFSETS.get(theme);
+
+        var dimId = getUUIDForTARDIS(operator.getLevelKey());
+        if (!doPortalsExistForTardis(dimId)) {
+            return;
+        }
+        var portal = getPortalsForTardis(dimId);
+
+        var interiorPortal = reloadEntityIfLoaded(portal.getInternalPortal());
+        var exteriorPortal = reloadEntityIfLoaded(portal.getShellPortal());
+
+        if (interiorPortal != portal.getInternalPortal() || exteriorPortal != portal.getShellPortal()) {
+            EXISTING_PORTALS.put(dimId, new PortalEntry(interiorPortal, exteriorPortal, ShellTheme.getShellTheme(theme), dimId));
+        }
+
+        var door = operator.getInternalDoor();
+        var interiorPos = getPortalPosition(
+                operator.getLevel(), door.getDoorPosition(), door.getTeleportRotation(),
+                getPortalPosForBlockPos(door.getTeleportPosition(), door.getTeleportRotation(), themeData.intDoor())
+        );
+        var result = updatePortalPosition(interiorPos, interiorPortal, exteriorPortal);
+
+        var location = operator.getPilotingManager().getCurrentLocation();
+        var exteriorPos = getPortalPosition(
+                location.getLevel(), location.getPosition(), location.getDirection(),
+                getPortalPosForBlockPos(location.getPosition(), location.getDirection(), themeData.shell())
+        );
+        result |= updatePortalPosition(exteriorPos, exteriorPortal, interiorPortal);
+
+        if (result) {
+            exteriorPortal.reloadAndSyncToClient();
+            interiorPortal.reloadAndSyncToClient();
+        }
+    }
+
     public static void createPortals(TardisLevelOperator operator) {
 
         if(operator.getPilotingManager().isInFlight()){
@@ -272,7 +395,7 @@ public class ImmersivePortals {
         }
 
         destroyPortals(operator);
-        UUID dimId = UUID.fromString(operator.getLevel().dimension().location().getPath());
+        UUID dimId = getUUIDForTARDIS(operator.getLevelKey());
 
         AestheticHandler aestheticsHandler = operator.getAestheticHandler();
         TardisInteriorManager interiorManager = operator.getInteriorManager();
@@ -286,40 +409,41 @@ public class ImmersivePortals {
             return;
         }
 
-        if (interiorManager.isCave() || door != null && !door.isOpen() || !operator.isTardisReady() || EXISTING_PORTALS.get(dimId) != null || door == null) {
-            return;
+        boolean open = door != null && door.isOpen();
+        TardisNavLocation location = pilotingManager.getCurrentLocation();
+
+        // If exterior is loaded we use it to check if door is open as well.
+        // The state we get for the interior door might be an outdated unloaded block entity.
+        if (location.getLevel().areEntitiesLoaded(ChunkPos.asLong(location.getPosition()))) {
+            var entity = location.getLevel().getBlockEntity(location.getPosition());
+            if (entity instanceof ExteriorShell shell && shell.isOpen()) {
+                open = true;
+            }
         }
 
-
-        TardisNavLocation location = pilotingManager.getCurrentLocation();
-        BlockPos entryPositionBPos = door.getTeleportPosition();
-        Vec3 entryPosition = new Vec3(entryPositionBPos.getX() + 0.5, entryPositionBPos.getY() + 1, entryPositionBPos.getZ() + 0.5);
-        BlockPos exteriorEntryBPos = location.getPosition();
-        Vec3 exteriorEntryPosition = new Vec3(exteriorEntryBPos.getX() + 0.5, exteriorEntryBPos.getY() + 1, exteriorEntryBPos.getZ() + 0.5);
+        if (interiorManager.isCave() || !open || !operator.isTardisReady() || EXISTING_PORTALS.get(dimId) != null || door == null) {
+            return;
+        }
 
         theme = operator.getAestheticHandler().getShellTheme();
         PortalOffets themeData = THEME_OFFSETS.get(theme);
         PortalOffets.OffsetData interiorDoor = themeData.intDoor();
         PortalOffets.OffsetData exteriorDoor = themeData.shell();
 
+        BlockPos entryPositionBPos = door.getTeleportPosition();
+        Vec3 entryPosition = getPortalPosForBlockPos(entryPositionBPos, door.getTeleportRotation(), interiorDoor);
+        BlockPos exteriorEntryBPos = location.getPosition();
+        Vec3 exteriorEntryPosition = getPortalPosForBlockPos(exteriorEntryBPos, location.getDirection(), exteriorDoor);
+
         Level operatorLevel = operator.getLevel();
 
+        var ext = getPortalPosition(location.getLevel(), location.getPosition(), location.getDirection(), exteriorEntryPosition);
+        var interior = getPortalPosition(operatorLevel, door.getDoorPosition(), door.getTeleportRotation(), entryPosition);
+        exteriorEntryPosition = ext.pos;
+        entryPosition = interior.pos;
 
-        switch (location.getDirection()) {
-            case EAST -> exteriorEntryPosition = exteriorEntryPosition.add(exteriorDoor.east());
-            case SOUTH -> exteriorEntryPosition = exteriorEntryPosition.add(exteriorDoor.south());
-            case WEST -> exteriorEntryPosition = exteriorEntryPosition.add(exteriorDoor.west());
-            case NORTH -> exteriorEntryPosition = exteriorEntryPosition.add(exteriorDoor.north());
-        }
-
-        switch (door.getTeleportRotation()) {
-            case EAST -> entryPosition = entryPosition.add(interiorDoor.east());
-            case SOUTH -> entryPosition = entryPosition.add(interiorDoor.south());
-            case WEST -> entryPosition = entryPosition.add(interiorDoor.west());
-            case NORTH -> entryPosition = entryPosition.add(interiorDoor.north());
-        }
-        DQuaternion extQuat = DQuaternion.rotationByDegrees(new Vec3(0, -1, 0), location.getDirection().toYRot());
-        DQuaternion interiorQuat = DQuaternion.rotationByDegrees(new Vec3(0, -1, 0), door.getTeleportRotation().toYRot());
+        var extQuat = ext.getQuaternion();
+        var interiorQuat = interior.getQuaternion();
 
         BotiPortalEntity exteriorPortal = createPortal(location.getLevel(), exteriorEntryPosition, entryPosition, operatorLevel.dimension(), extQuat);
         BotiPortalEntity interiorPortal = createDestPortal(exteriorPortal, entryPosition, ImmersivePortals.BOTI_PORTAL.get(), interiorQuat);

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
@@ -87,7 +87,7 @@ public class ImmersivePortals {
 
     public static boolean isTeleportingPortalPresent(UUID uuid) {
         if (doPortalsExistForTardis(uuid)) {
-            var portal = getPortalsForTardis(uuid);
+            PortalEntry portal = getPortalsForTardis(uuid);
             return portal.getInternalPortal().teleportable && portal.getShellPortal().teleportable;
         } else {
             return false;
@@ -314,7 +314,7 @@ public class ImmersivePortals {
     }
 
     private static Vec3 getPortalPosForBlockPos(BlockPos pos, Direction direction, PortalOffets.OffsetData offset) {
-        var returnPos = new Vec3(pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5);
+        Vec3 returnPos = new Vec3(pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5);
 
         return switch (direction) {
             case EAST -> returnPos.add(offset.east());
@@ -351,7 +351,7 @@ public class ImmersivePortals {
                 entity.isRemoved() && entity.level() instanceof ServerLevel sl &&
                 sl.areEntitiesLoaded(ChunkPos.asLong(entity.blockPosition()))
         ) {
-            var newEntity = sl.getEntity(entity.getUUID());
+            Entity newEntity = sl.getEntity(entity.getUUID());
             if (newEntity != null && newEntity.getClass() == entity.getClass()) {
                 //noinspection unchecked
                 return (T) newEntity;
@@ -369,28 +369,28 @@ public class ImmersivePortals {
         }
         PortalOffets themeData = THEME_OFFSETS.get(theme);
 
-        var dimId = getUUIDForTARDIS(operator.getLevelKey());
+        UUID dimId = getUUIDForTARDIS(operator.getLevelKey());
         if (!doPortalsExistForTardis(dimId)) {
             return;
         }
-        var portal = getPortalsForTardis(dimId);
+        PortalEntry portal = getPortalsForTardis(dimId);
 
-        var interiorPortal = reloadEntityIfLoaded(portal.getInternalPortal());
-        var exteriorPortal = reloadEntityIfLoaded(portal.getShellPortal());
+        BotiPortalEntity interiorPortal = reloadEntityIfLoaded(portal.getInternalPortal());
+        BotiPortalEntity exteriorPortal = reloadEntityIfLoaded(portal.getShellPortal());
 
         if (interiorPortal != portal.getInternalPortal() || exteriorPortal != portal.getShellPortal()) {
             EXISTING_PORTALS.put(dimId, new PortalEntry(interiorPortal, exteriorPortal, ShellTheme.getShellTheme(theme), dimId));
         }
 
-        var door = operator.getInternalDoor();
-        var interiorPos = getPortalPosition(
+        TardisInternalDoor door = operator.getInternalDoor();
+        PositionHolder interiorPos = getPortalPosition(
                 operator.getLevel(), door.getDoorPosition(), door.getTeleportRotation(),
                 getPortalPosForBlockPos(door.getTeleportPosition(), door.getTeleportRotation(), themeData.intDoor())
         );
-        var result = updatePortalPosition(interiorPos, interiorPortal, exteriorPortal);
+        boolean result = updatePortalPosition(interiorPos, interiorPortal, exteriorPortal);
 
-        var location = operator.getPilotingManager().getCurrentLocation();
-        var exteriorPos = getPortalPosition(
+        TardisNavLocation location = operator.getPilotingManager().getCurrentLocation();
+        PositionHolder exteriorPos = getPortalPosition(
                 location.getLevel(), location.getPosition(), location.getDirection(),
                 getPortalPosForBlockPos(location.getPosition(), location.getDirection(), themeData.shell())
         );
@@ -441,7 +441,7 @@ public class ImmersivePortals {
         // If exterior is loaded we use it to check if door is open as well.
         // The state we get for the interior door might be an outdated unloaded block entity.
         if (location.getLevel().areEntitiesLoaded(ChunkPos.asLong(location.getPosition()))) {
-            var entity = location.getLevel().getBlockEntity(location.getPosition());
+            BlockEntity entity = location.getLevel().getBlockEntity(location.getPosition());
             if (entity instanceof ExteriorShell shell && shell.isOpen()) {
                 open = true;
             }
@@ -463,14 +463,14 @@ public class ImmersivePortals {
 
         Level operatorLevel = operator.getLevel();
 
-        var ext = getPortalPosition(location.getLevel(), location.getPosition(), location.getDirection(), exteriorEntryPosition);
-        var interior = getPortalPosition(operatorLevel, door.getDoorPosition(), door.getTeleportRotation(), entryPosition);
+        PositionHolder ext = getPortalPosition(location.getLevel(), location.getPosition(), location.getDirection(), exteriorEntryPosition);
+        PositionHolder interior = getPortalPosition(operatorLevel, door.getDoorPosition(), door.getTeleportRotation(), entryPosition);
         exteriorEntryPosition = ext.pos;
         entryPosition = interior.pos;
         boolean airship = ext.airship || interior.airship;
 
-        var extQuat = ext.getQuaternion();
-        var interiorQuat = interior.getQuaternion();
+        DQuaternion extQuat = ext.getQuaternion();
+        DQuaternion interiorQuat = interior.getQuaternion();
 
         BotiPortalEntity exteriorPortal = createPortal(location.getLevel(), exteriorEntryPosition, entryPosition, operatorLevel.dimension(), extQuat);
         BotiPortalEntity interiorPortal = createDestPortal(exteriorPortal, entryPosition, ImmersivePortals.BOTI_PORTAL.get(), interiorQuat);

--- a/common/src/main/java/whocraft/tardis_refined/compat/valkyrienskies/VSHelper.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/valkyrienskies/VSHelper.java
@@ -156,6 +156,15 @@ public class VSHelper {
         }
     }
 
+    public static Vec3 toWorldRotation(Level level, BlockPos position, Vec3 direction) {
+        Ship ship = VSGameUtilsKt.getShipManagingPos(level, position);
+        if (ship != null) {
+            return vectorToVector(ship.getShipToWorld().transformDirection(vectorToVector(direction)));
+        } else {
+            return direction;
+        }
+    }
+
     public static BlockPos toWorldPosition(Level level, BlockPos blockPos) {
         Vector3d pos = blockPosToVector(blockPos);
         Vector3d worldPos = VSGameUtilsKt.getWorldCoordinates(level, blockPos, pos);
@@ -191,6 +200,14 @@ public class VSHelper {
 
     public static Vector3d blockPosToVector(BlockPos blockPos) {
         return new Vector3d(blockPos.getX(), blockPos.getY(), blockPos.getZ());
+    }
+
+    public static Vector3d vectorToVector(Vec3 vector) {
+        return new Vector3d(vector.x, vector.y, vector.z);
+    }
+
+    public static Vec3 vectorToVector(Vector3d vector) {
+        return new Vec3(vector.x, vector.y, vector.z);
     }
 
     public static BlockPos vectorToBlockPos(Vector3d vector) {

--- a/common/src/main/java/whocraft/tardis_refined/constants/ModMessages.java
+++ b/common/src/main/java/whocraft/tardis_refined/constants/ModMessages.java
@@ -44,6 +44,7 @@ public class ModMessages {
     public static final String UI_UPGRADES_BUY = ui("upgrades.buy_ability");
     public static final String UI_NO_INSTALLED_SUBSYSTEMS = ui("no_installed_subsystems");
     public static final String CONFIG_IP_COMPAT = config("immersive_portals");
+    public static final String CONFIG_IP_VS_COLLISION = config("immersive_portals_vs_collision");
     public static final String CONFIG_IP_TELEPORTATION = config("immersive_portals_teleportation_mode");
     public static final String CONFIG_IP_TELEPORTATION_VS = config("immersive_portals_teleportation_mode_vs");
     public static final String CONFIG_CONTROL_NAMES = config("control_names");

--- a/common/src/main/java/whocraft/tardis_refined/constants/ModMessages.java
+++ b/common/src/main/java/whocraft/tardis_refined/constants/ModMessages.java
@@ -44,6 +44,8 @@ public class ModMessages {
     public static final String UI_UPGRADES_BUY = ui("upgrades.buy_ability");
     public static final String UI_NO_INSTALLED_SUBSYSTEMS = ui("no_installed_subsystems");
     public static final String CONFIG_IP_COMPAT = config("immersive_portals");
+    public static final String CONFIG_IP_TELEPORTATION = config("immersive_portals_teleportation_mode");
+    public static final String CONFIG_IP_TELEPORTATION_VS = config("immersive_portals_teleportation_mode_vs");
     public static final String CONFIG_CONTROL_NAMES = config("control_names");
     public static final String CONFIG_IDLE_CONSOLE_ANIMS = config("console_idle_animations");
     public static final String CONFIG_RENDER_VORTEX_IN_DOOR = config("config_render_vortex_in_door");

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     include "dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${rootProject.cardinal_version}"
 
     // Sodium
-    modImplementation "maven.modrinth:sodium:${rootProject.sodium_version}"
+    modCompileOnly "maven.modrinth:sodium:${rootProject.sodium_version}"
 
     modImplementation "com.terraformersmc:modmenu:${rootProject.mod_menu_version}"
     modImplementation "curse.maven:jei-238222:${rootProject.jei_fabric_version}"

--- a/forge/src/main/java/whocraft/tardis_refined/common/data/LangProviderEnglish.java
+++ b/forge/src/main/java/whocraft/tardis_refined/common/data/LangProviderEnglish.java
@@ -321,6 +321,7 @@ public class LangProviderEnglish extends LanguageProvider {
 
         /*Config*/
         add(ModMessages.CONFIG_IP_COMPAT, "Immersive Portals Compatibility?");
+        add(ModMessages.CONFIG_IP_VS_COLLISION, "Immersive Portals Valkyrien Skies Collision");
         add(ModMessages.CONFIG_IP_TELEPORTATION, "Immersive Portals Teleportation Mode");
         add(ModMessages.CONFIG_IP_TELEPORTATION_VS, "Immersive Portals Teleportation Mode on Valkyrien Skies ships");
         add(ModMessages.CONFIG_CONTROL_NAMES, "Render control names?");

--- a/forge/src/main/java/whocraft/tardis_refined/common/data/LangProviderEnglish.java
+++ b/forge/src/main/java/whocraft/tardis_refined/common/data/LangProviderEnglish.java
@@ -321,6 +321,8 @@ public class LangProviderEnglish extends LanguageProvider {
 
         /*Config*/
         add(ModMessages.CONFIG_IP_COMPAT, "Immersive Portals Compatibility?");
+        add(ModMessages.CONFIG_IP_TELEPORTATION, "Immersive Portals Teleportation Mode");
+        add(ModMessages.CONFIG_IP_TELEPORTATION_VS, "Immersive Portals Teleportation Mode on Valkyrien Skies ships");
         add(ModMessages.CONFIG_CONTROL_NAMES, "Render control names?");
         add(ModMessages.CONFIG_BANNED_DIMENSIONS, "Banned Dimensions");
         add(ModMessages.CONFIG_IDLE_CONSOLE_ANIMS, "Play idle console animations");


### PR DESCRIPTION
I recently noticed that Valkyrien Skies and Immersive Portals are now compatible with each other.

Since TardisRefined supports both of them, I thought it would make sense to make sure it would work well when both are installed at once. This pull request makes sure of that.

The main thing is making sure the portal is rotated properly when on a Valkyrien Skies ship, which I do by rotating the height and width vectors. The next thing is to make the portal follow the TARDIS as the ship moves, which I handle in the tick loop. While I was at it I also fixed a bug where the portal sometimes wouldn't appear when opened from the outside.

Then I unfortunately noticed that the compatibility between Immersive Portals and Valkyrien Skies is not perfect. First off, at some angles walking through the portal is impossible because of the door's collision box. Secondly, sometimes if the ship is moving the player will be sent flying through walls several thousands of blocks away from the door. Since these are upstream bugs that might be fixed in the future, I added some configurable workarounds that are enabled by default.

The first workaround is to let the player choose if the portal can directly teleport the player, or if it should operate as if Immersive Portals integration was disabled and just use the portal for visuals. I added 2 separate config options to control this, one for when at least one door is on a ship, and another for when neither of them are. I also added a config option to disable the collision of the door when on a ship which would solve the issue of being unable to enter, but it won't solve the other bug, hence why I set the Valkyrien Skies setting to teleport as if Immersive Portals integration was disabled by default.

I also changed Sodium to compileOnly because the correct version of Sodium for the latest version of Immersive Portals does not run in the dev environment because it doesn't like the LWJGL-version.