### PR TITLE
Fix Respawn Anchor and /spawnpoint command not working inside the TARDIS.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,4 +25,5 @@
 - Bug fix: Fixed the TARDIS forgetting its current dimension on world reload
 - Bug fix: Fix materialize around upgrade not working.
 - Bug fix: Fixed TARDIS being broken when created in a non-overworld dimension.
+- Bug fix: Respawn Anchor and /spawnpoint command not working inside the TARDIS
 

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisInteriorManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisInteriorManager.java
@@ -458,6 +458,10 @@ public class TardisInteriorManager extends TickableHandler {
         this.isWaitingToGenerate = false;
     }
 
+    public boolean canBedSetSpawn() {
+        return false; //TODO Upgrade?
+    }
+
     /**
      * Returns whether a Tardis has enough fuel to perform an interior change
      *

--- a/common/src/main/java/whocraft/tardis_refined/mixin/ServerPlayerMixin.java
+++ b/common/src/main/java/whocraft/tardis_refined/mixin/ServerPlayerMixin.java
@@ -1,13 +1,17 @@
 package whocraft.tardis_refined.mixin;
 
+import com.llamalad7.mixinextras.injector.WrapWithCondition;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import whocraft.tardis_refined.common.capability.tardis.TardisLevelOperator;
 import whocraft.tardis_refined.common.util.PlayerUtil;
 import whocraft.tardis_refined.constants.ModMessages;
 import whocraft.tardis_refined.registry.TRDimensionTypes;
@@ -15,20 +19,37 @@ import whocraft.tardis_refined.registry.TRDimensionTypes;
 @Mixin(ServerPlayer.class)
 public class ServerPlayerMixin {
 
+    @Unique
+    private boolean tardis_refined$canBedSetSpawn() {
+        ServerPlayer serverPlayer = (ServerPlayer) (Object) this;
+        if(serverPlayer.level().dimensionTypeId() == TRDimensionTypes.TARDIS){
+            return TardisLevelOperator.get(serverPlayer.serverLevel()).map(
+                    operator -> operator.getInteriorManager().canBedSetSpawn()
+            ).orElse(true);
+        }
+        return true;
+    }
+
     @Inject(method = "stopSleepInBed(ZZ)V", at = @At("HEAD"))
     private void stopSleepInBed(boolean bl, boolean bl2, CallbackInfo ci) {
         ServerPlayer serverPlayer = (ServerPlayer) (Object) this;
-        if (serverPlayer.level().dimensionTypeId() == TRDimensionTypes.TARDIS) {
+        if (!tardis_refined$canBedSetSpawn()) {
             PlayerUtil.sendMessage(serverPlayer, ModMessages.TARDIS_SLEEP_END, true);
         }
     }
 
-    @Inject(method = "setRespawnPosition(Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/core/BlockPos;FZZ)V", at = @At("HEAD"), cancellable = true)
-    public void setRespawnPosition(ResourceKey<Level> resourceKey, BlockPos blockPos, float f, boolean bl, boolean bl2, CallbackInfo ci) {
-        ServerPlayer serverPlayer = (ServerPlayer) (Object) this;
-        if(serverPlayer.level().dimensionTypeId() == TRDimensionTypes.TARDIS){
-            ci.cancel();
-        }
+    @WrapWithCondition(
+            method = "startSleepInBed",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/level/ServerPlayer;setRespawnPosition(Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/core/BlockPos;FZZ)V"
+            )
+    )
+    public boolean setBedRespawnPosition(
+            ServerPlayer instance, ResourceKey<Level> resourceKey,
+            @Nullable BlockPos blockPos, float f, boolean bl, boolean bl2
+    ) {
+        return tardis_refined$canBedSetSpawn();
     }
 
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -84,8 +84,8 @@ dependencies {
     modImplementation("net.createmod.ponder:Ponder-Forge-${minecraft_version}:${ponder_version}")
     modImplementation("dev.engine-room.flywheel:flywheel-forge-api-${minecraft_version}:${flywheel_version}")
     modImplementation("dev.engine-room.flywheel:flywheel-forge-${minecraft_version}:${flywheel_version}")
-    modImplementation(annotationProcessor("io.github.llamalad7:mixinextras-common:${mixin_extras_version}"))
-    implementation("io.github.llamalad7:mixinextras-forge:${mixin_extras_version}")
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:${mixin_extras_version}"))
+    implementation(include("io.github.llamalad7:mixinextras-forge:${mixin_extras_version}"))
 
 
     common(project(path: ":common", configuration: "namedElements")) { transitive false }

--- a/gradle.properties
+++ b/gradle.properties
@@ -70,8 +70,8 @@ forge_config_api_port_version=8.0.0
 immersive_portals_version=v3.3.7-mc1.20.1
 dev_auth_module_fabric=fabric
 dev_auth_fabric_version=1.1.2
-#(Required by Immersive Portals Fabric)
-mixin_extras_version=0.4.1
+#Required for some mixins
+mixin_extras_version=0.5.3
 cloth_config_fabric_version=11.1.118
 
 #Forge Dependencies


### PR DESCRIPTION
I recently discovered that in older versions of the mod, specifically from 0.1 all the way until version 2.1.3 it was possible to use respawn anchors to set your spawnpoint inside the TARDIS. However, this was not possible in version 2.1.4 and later. I also noticed that the /spawnpoint command wasn't working past 2.1.4 either.

Looking at the commit history, it seemed like your intention was to allow sleeping in beds without setting the player's spawn point, but still allow respawn anchors since they have never been disabled in the dimension type. In either case I think the /spawnpoint command should always work.

Let me know if you'd like to keep respawn anchors nonfunctional, or if they should be locked behind some upgrade.

Note that this pull request also adds mixinextras to the forge version's jar file, since that's necessary for the mixin to work properly.