### PR TITLE
Fix Immersive Portals compat on Forge.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,4 +35,5 @@
 - Bug fix: Immersive Portals portal sometimes not spawning when opened from exterior.
 - Bug fix: Respawn Anchor and /spawnpoint command not working inside the TARDIS
 - Bug fix: Capability deserialization fails on Arclight
+- Bug fix: Immersive Portals compatibility crashing the game on Forge.
 

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortals.java
@@ -126,7 +126,9 @@ public class ImmersivePortals {
         BOTI_PORTAL = ENTITY_TYPES.register("boti_portal", () -> registerStatic(BotiPortalEntity::new, MobCategory.MISC, 1, 1, 96, 20, "boti_portal"));
 
         setupEvents();
+    }
 
+    public static void postInit() {
         // Set up for Portals!
         setupPortalsForShellThemes();
     }

--- a/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortalsClient.java
+++ b/common/src/main/java/whocraft/tardis_refined/compat/portals/ImmersivePortalsClient.java
@@ -3,16 +3,23 @@ package whocraft.tardis_refined.compat.portals;
 import com.mojang.blaze3d.pipeline.RenderTarget;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
 import qouteall.imm_ptl.core.compat.IPPortingLibCompat;
 import qouteall.imm_ptl.core.render.context_management.PortalRendering;
 
 public class ImmersivePortalsClient {
 
+    @FunctionalInterface
+    public interface RendererRegistrator {
+        <T extends Entity> void register(EntityType<? extends T> type, EntityRendererProvider<T> renderer);
+    }
+
     @Environment(EnvType.CLIENT)
-    public static void doClientRenderers() {
+    public static void doClientRenderers(RendererRegistrator entityRendererRegistrator) {
         if (ImmersivePortals.BOTI_PORTAL == null) return;
-        EntityRendererRegistry.register(ImmersivePortals.BOTI_PORTAL.get(), BotiPortalRenderer::new);
+        entityRendererRegistrator.register(ImmersivePortals.BOTI_PORTAL.get(), BotiPortalRenderer::new);
     }
 
     @Environment(EnvType.CLIENT)

--- a/fabric/src/main/java/whocraft/tardis_refined/fabric/TardisRefinedFabric.java
+++ b/fabric/src/main/java/whocraft/tardis_refined/fabric/TardisRefinedFabric.java
@@ -84,6 +84,7 @@ public class TardisRefinedFabric implements ModInitializer {
         if (ModCompatChecker.immersivePortals()) {
             if (TRConfig.COMMON.COMPATIBILITY_IP.get()) {
                 ImmersivePortals.init();
+                ImmersivePortals.postInit();
                 PortalsCompatFabric.init();
             }
         } else {

--- a/fabric/src/main/java/whocraft/tardis_refined/fabric/TardisRefinedFabricClient.java
+++ b/fabric/src/main/java/whocraft/tardis_refined/fabric/TardisRefinedFabricClient.java
@@ -88,7 +88,7 @@ public class TardisRefinedFabricClient implements ClientModInitializer {
         EntityRendererRegistry.register(TREntityRegistry.CONTROL_ENTITY.get(), ControlEntityRenderer::new);
 
         if (ModCompatChecker.immersivePortals()) {
-            ImmersivePortalsClient.doClientRenderers();
+            ImmersivePortalsClient.doClientRenderers(EntityRendererRegistry::register);
         }
 
     }

--- a/forge/src/main/java/whocraft/tardis_refined/forge/ClientModBus.java
+++ b/forge/src/main/java/whocraft/tardis_refined/forge/ClientModBus.java
@@ -37,6 +37,8 @@ import whocraft.tardis_refined.client.renderer.blockentity.shell.GlobalShellRend
 import whocraft.tardis_refined.client.renderer.blockentity.shell.RootShellRenderer;
 import whocraft.tardis_refined.client.renderer.entity.ControlEntityRenderer;
 import whocraft.tardis_refined.common.items.DimensionSamplerItem;
+import whocraft.tardis_refined.compat.ModCompatChecker;
+import whocraft.tardis_refined.compat.portals.ImmersivePortalsClient;
 import whocraft.tardis_refined.mixin.forge.ReloadableResourceManagerMixin;
 import whocraft.tardis_refined.overlays.TardisRefinedOverlay;
 import whocraft.tardis_refined.registry.RegistrySupplier;
@@ -121,6 +123,9 @@ public class ClientModBus {
 
         ItemProperties.register(TRItemRegistry.TEST_TUBE.get(), new ResourceLocation(TardisRefined.MODID, "is_sampled"), (itemStack, clientLevel, livingEntity, i) -> DimensionSamplerItem.hasDimAtAll(itemStack) ? 1 : 0);
 
+        if (ModCompatChecker.immersivePortals()) {
+            ImmersivePortalsClient.doClientRenderers(EntityRenderers::register);
+        }
     }
 
     @SubscribeEvent(priority = EventPriority.HIGH)

--- a/forge/src/main/java/whocraft/tardis_refined/forge/TardisRefinedForge.java
+++ b/forge/src/main/java/whocraft/tardis_refined/forge/TardisRefinedForge.java
@@ -7,6 +7,7 @@ import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import whocraft.tardis_refined.TRConfig;
 import whocraft.tardis_refined.TardisRefined;
@@ -25,6 +26,7 @@ public class TardisRefinedForge {
         TardisRefined.init();
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         modEventBus.addListener(this::onGatherData);
+        modEventBus.addListener(this::onPostInit);
 
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, TRConfig.COMMON_SPEC);
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, TRConfig.CLIENT_SPEC);
@@ -34,7 +36,6 @@ public class TardisRefinedForge {
             CuriosUtil.init();
         }
 
-        //TODO IP compat for forge?
        if (ModCompatChecker.immersivePortals()) {
             if(TRConfig.COMMON.COMPATIBILITY_IP.get()) {
                 ImmersivePortals.init();
@@ -46,6 +47,12 @@ public class TardisRefinedForge {
 
         if (ModCompatChecker.create()) {
             CreateIntergrationsForge.init();
+        }
+    }
+
+    public void onPostInit(InterModProcessEvent event) {
+        if (ModCompatChecker.immersivePortals() && TRConfig.COMMON.COMPATIBILITY_IP.get()) {
+            ImmersivePortals.postInit();
         }
     }
 


### PR DESCRIPTION
There are currently 2 issues that prevent the Immersive Portals compatibility from working on Forge.
1. The shell themes are not available when Forge wants to initialise the Immersive Portals compatibility, so I delay the shell theme setup step to the InterModProcessEvent.
2. The renderer for the boti door entity is not registered on Forge, so I changed the renderer registration function to be loader-agnostic and called it from Forge.