### PR TITLE
Remove forceloading

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,4 +35,5 @@
 - Bug fix: Immersive Portals portal sometimes not spawning when opened from exterior.
 - Bug fix: Respawn Anchor and /spawnpoint command not working inside the TARDIS
 - Bug fix: Capability deserialization fails on Arclight
+- Bug fix: TARDIS removes forceloading when taking off and landing.
 

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisExteriorManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisExteriorManager.java
@@ -1,12 +1,10 @@
 package whocraft.tardis_refined.common.tardis.manager;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.SectionPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import whocraft.tardis_refined.common.block.shell.GlobalShellBlock;
@@ -139,15 +137,10 @@ public class TardisExteriorManager extends BaseHandler {
         if (currentPosition != null) {
             BlockPos lastKnownLocationPosition = currentPosition.getPosition();
             ServerLevel lastKnownLocationLevel = currentPosition.getLevel();
-            ChunkPos chunkPos = lastKnownLocationLevel.getChunk(lastKnownLocationPosition).getPos();
-            //Force load chunk
-            TardisPilotingManager.setChunkForced(lastKnownLocationLevel, chunkPos, true); //Set chunk to be force loaded to properly remove block
             //Remove block
             if (lastKnownLocationLevel.getBlockEntity(lastKnownLocationPosition) instanceof GlobalShellBlockEntity globalShellBlockEntity) {
                 lastKnownLocationLevel.removeBlock(lastKnownLocationPosition, false); //Set block to air with drop items flag to false
             }
-            //Un-force load chunk
-	        TardisPilotingManager.setChunkForced(lastKnownLocationLevel, chunkPos, false); //Set chunk to not be force loaded after we remove the block
         }
     }
 
@@ -155,23 +148,11 @@ public class TardisExteriorManager extends BaseHandler {
      * Setup the landing data updates and physical placement of the shell block
      */
     public void startLanding(TardisLevelOperator operator, TardisNavLocation location) {
-        ServerLevel targetLevel = location.getLevel();
-        BlockPos lastKnownLocationPosition = location.getPosition();
-        ChunkPos chunkPos = location.getLevel().getChunk(lastKnownLocationPosition).getPos();
-
         this.isLanding = true;
-
-        //Force load target chunk
-	    TardisPilotingManager.setChunkForced(targetLevel, chunkPos, true); //Set chunk to be force loaded to properly place block
-	    this.isLanding = true;
         operator.tardisClientData().setIsLanding(true);
         operator.tardisClientData().sync();
 
         this.placeExteriorBlockForLanding(location);
-
-        //Un-force load target chunk
-	    TardisPilotingManager.setChunkForced(targetLevel, chunkPos, false); //Set chunk to be not be force loaded after we place the block
-
     }
 
     /**

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -400,15 +400,10 @@ public class TardisPilotingManager extends TickableHandler {
         BlockPos position = location.getPosition();
         Direction direction = location.getDirection();
 
-        ChunkPos chunkPos = level.getChunk(position).getPos();
-
         var maxBuildHeight = level.getMaxBuildHeight();
         var minHeight = level.getMinBuildHeight();
 
         List<TardisNavLocation> solutionsInRow = new ArrayList<>();
-
-        //Force load chunk to search positions
-        setChunkForced(level, chunkPos, true);
 
         Optional<TardisNavLocation> closest = Optional.empty();
 
@@ -464,9 +459,6 @@ public class TardisPilotingManager extends TickableHandler {
             closest = this.findClosestValidPositionFromTarget(solutionsInRow, location);
 
         }
-
-        //Unforce chunk after we are done searching
-        setChunkForced(level, chunkPos, false);
 
         return closest;
     }
@@ -1398,16 +1390,6 @@ public class TardisPilotingManager extends TickableHandler {
                 .max()
                 .orElse(1);
         return this.speedModifier;
-    }
-
-    public static void setChunkForced(ServerLevel level, ChunkPos pos, boolean forced) {
-        if (ModCompatChecker.valkyrienSkies() && VSHelper.isChunkInShipyard(pos)) {
-            VSHelper.toWorldShipChunks(level, pos).forEach(p -> {
-                level.setChunkForced(p.x, p.z, forced);
-            });
-        } else {
-            level.setChunkForced(pos.x, pos.z, forced);
-        }
     }
 
 }


### PR DESCRIPTION
At the moment, the TARDIS turns forceloading on and then immediately off again when taking off or landing.

This means that if the chunk is forceloaded by some other mod/datapack, the TARDIS will remove that forceloading, which is not ideal. I tried removing it and could confirm that the mod does indeed continue working normally.

When I asked on Discord, there were 2 main reasons why forceloading was added.
1. **To fix TARDIS duplication.** While I don't know all the sources of TARDIS duplication, the only one I was able to reproduce was the one where the server shuts down while the TARDIS is taking off. This would not be caused by the lack of forceloading, but rather by the fact that the TARDIS doesn't serialise `ticksTakingOff`, so it thinks it's already in flight when the server starts up again and thus never removes the exterior. Also, the new automatic de-duplication mechanic makes sure the duplicate automatically deletes itself anyway.
2. **To prevent the player from falling through Valkyrien Skies ships when exiting the TARDIS.** As far as I understand it, ships don't actually load in when a chunk is forceloaded, but only when a player is nearby, which means forceloading won't make a difference. I'd also argue that the player falling through ships bug should be addressed upstream since it also affects other mods, and it should hopefully be (mostly) fixed now anyway.

Closes #551