### PR TITLE
Remove unnecessary Valkyrien Skies chunkloading hack.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,7 +20,6 @@
 - Bug fix: Impossible to enter TARDIS when on a Valkyrien Skies ship.
 - Bug fix: TARDIS shows shipyard coordinates when on a Valkyrien Skies ship.
 - Bug fix: Player does not face the right horizontal direction when entering/exiting a TARDIS on a Valkyrien Skies ship.
-- Partial bug fix: Player falls through Valkyrien Skies ship when exiting the TARDIS.
 - Bug fix: TARDIS does not take Valkyrien Skies ships into account when computing travel distance.
 - Bug fix: TARDIS does not automatically try to land on ships.
 - Bug fix: Flickering when spectating TARDIS exterior on a Valkyrien Skies ship.

--- a/common/src/main/java/whocraft/tardis_refined/common/util/LevelHelper.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/util/LevelHelper.java
@@ -2,11 +2,7 @@ package whocraft.tardis_refined.common.util;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.phys.Vec3;
-import whocraft.tardis_refined.compat.ModCompatChecker;
-import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -72,15 +68,5 @@ public class LevelHelper {
 
         return posList;
     }
-
-	public static void loadShips(ServerLevel level, ChunkPos orgPos) {
-		// On Fabric, we fall through ships if we don't load the chunk in advance.
-		if (!Platform.isForge() && ModCompatChecker.valkyrienSkies() && VSHelper.isChunkInShipyard(orgPos)) {
-			List<ChunkPos> positions = VSHelper.toWorldShipChunks(level, orgPos).toList();
-			positions.forEach(p -> {
-				level.getChunk(p.x, p.z); // Load the chunk now.
-			});
-		}
-	}
 
 }

--- a/common/src/main/java/whocraft/tardis_refined/common/util/TRTeleporter.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/util/TRTeleporter.java
@@ -2,7 +2,6 @@ package whocraft.tardis_refined.common.util;
 
 import com.google.common.base.Preconditions;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.SectionPos;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.server.TickTask;
 import net.minecraft.server.level.ServerLevel;
@@ -142,12 +141,6 @@ public class TRTeleporter {
     private static Entity teleportLogicCommon(Entity pEntity, ServerLevel destination, double pX, double pY, double pZ, float pYaw, float pPitch) {
 
         pEntity.setDeltaMovement(Vec3.ZERO);
-
-        LevelHelper.loadShips(
-                destination,
-                new ChunkPos(SectionPos.blockToSectionCoord(pX), SectionPos.blockToSectionCoord(pZ))
-        );
-
 
         Entity teleportedEntity;
         if (pEntity instanceof ServerPlayer serverPlayer) {


### PR DESCRIPTION
Been thinking about this for a while now.

In #542 I added a small hack which I hoped would fix the issue where the player sometimes falls through the ship when exiting the TARDIS. In retrospect, this hack didn't really do that at all, at best it might have reduced the probability of falling through ships slightly.

Considering that this should hopefully be fixed upstream now, I think it's best to remove this hack completely.
Since there hasn't been any official release containing the hack, I thought it was fair to remove it from the changelog as well.