### PR TITLE
Fix TARDIS getting stuck in flight when destination is reached and throttle is set to 0 before dematerialization is complete.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -45,3 +45,4 @@
 - Bug fix: Create TARDIS Summary does not display all lines correctly.
 - Bug fix: Crash when closing the game near a TARDIS Create display while Valkyrien Skies is installed.
 - Bug fix: Recently created TARDIS keeps printing "Preparing spawn area: 100%" every time a chunk loads until the server is restarted.
+- Bug fix: TARDIS gets stuck in flight when destination is reached and throttle is set to 0 before dematerialization is complete.

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -748,7 +748,7 @@ public class TardisPilotingManager extends TickableHandler {
      * @return true if able to, false if not
      */
     public boolean canEndFlight() {
-        return isInFlight && ticksInFlight >= (20 * 5) && ticksTakingOff <= 0 && (distanceCovered >= flightDistance || this.autoLand) && !this.isCrashing;
+        return isInFlight && ticksTakingOff <= 0 && (distanceCovered >= flightDistance || this.autoLand) && !this.isCrashing;
     }
 
     public void recalculateFlightDistance() {


### PR DESCRIPTION
This allows the TARDIS to rematerialize immediately after dematerializing, which is useful for short hops such as just changing the exterior rotation.