### PR TITLE
Respect logical height and ignore safety checks for landing pads.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 #### Changes
 - Amethyst Screwdriver tooltip now is colored gray.
 - Updated create-fabric integration to create 6.
+- Landing pad is now always considered a safe landing location, even when entrance blocked or above the nether roof.
 
 #### Configs
 - New config option to disable teleportation for the Immersive Portals portal, instead teleporting the player directly as if Immersive Portals integration was disabled.
@@ -47,3 +48,4 @@
 - Bug fix: Recently created TARDIS keeps printing "Preparing spawn area: 100%" every time a chunk loads until the server is restarted.
 - Bug fix: The back button in the Waypoint screen traps users in an infinite loop and deletes waypoints.
 - Bug fix: AR particles sometimes render below the control.
+- Bug fix: TARDIS does not respect logical height.

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -504,7 +504,7 @@ public class TardisPilotingManager extends TickableHandler {
         for (BlockPos airPos : filteredForAir) {
 
             // Ignore any higher scans above the logical height (e.g. nether roof).
-            if (airPos.getY() >= (level.getMinBuildHeight() + level.getLogicalHeight())) {
+            if (!isWithinLogicalHeight(level, airPos)) {
                 continue;
             }
 
@@ -645,13 +645,20 @@ public class TardisPilotingManager extends TickableHandler {
         return this.isExitPositionSafeOrLandingPad(location.getLevel(), location.getPosition(), location.getDirection());
     }
 
+    private boolean isWithinLogicalHeight(ServerLevel level, BlockPos pos) {
+        if (ModCompatChecker.valkyrienSkies() && VSHelper.isBlockInShipyard(level, pos)) {
+            return true;
+        }
+        return pos.getY() < (level.getMinBuildHeight() + level.getLogicalHeight());
+    }
+
     /**
      * If there is a 2 block vertical space for the exterior to be placed at, and the block below the exterior is solid
      */
     private boolean canPlaceTardis(TardisNavLocation location) {
         ServerLevel targetLevel = location.getLevel();
         BlockPos pos = location.getPosition();
-        boolean isBelowLogicalHeight = pos.getY() < (targetLevel.getMinBuildHeight() + targetLevel.getLogicalHeight()) || onLandingPad(location.getLevel(), location.getPosition());
+        boolean isBelowLogicalHeight = isWithinLogicalHeight(location.getLevel(), location.getPosition()) || onLandingPad(location.getLevel(), location.getPosition());
         return isBelowLogicalHeight && this.isLegalLandingBlock(targetLevel, pos, LandingBlockType.AIR) && isLegalLandingBlock(targetLevel, pos.above(), LandingBlockType.AIR) && isLegalLandingBlock(targetLevel, pos.below(), LandingBlockType.GROUND);
     }
 

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -44,6 +44,7 @@ import whocraft.tardis_refined.compat.valkyrienskies.VSHelper;
 import whocraft.tardis_refined.constants.ModMessages;
 import whocraft.tardis_refined.constants.NbtConstants;
 import whocraft.tardis_refined.patterns.ConsolePattern;
+import whocraft.tardis_refined.registry.TRBlockRegistry;
 import whocraft.tardis_refined.registry.TRSoundRegistry;
 import whocraft.tardis_refined.registry.TRUpgrades;
 
@@ -417,7 +418,7 @@ public class TardisPilotingManager extends TickableHandler {
         }
 
         //First manually check if the exact target position can allow us to place the Tardis
-        if (this.canPlaceTardis(location) && this.isExitPositionSafe(location) && !shouldLandOnShip) {
+        if (this.canPlaceTardis(location) && this.isExitPositionSafeOrLandingPad(location) && !shouldLandOnShip) {
             solutionsInRow.add(location);
         }
 
@@ -435,7 +436,7 @@ public class TardisPilotingManager extends TickableHandler {
                 List<BlockPos> surroundingPositionsSameYLevel = LevelHelper.getBlockPosInRadius(position, radius, true, false);
                 for (BlockPos directionOffset : surroundingPositionsSameYLevel) {
                     TardisNavLocation nextLocation = new TardisNavLocation(directionOffset, location.getDirection(), location.getLevel());
-                    if (this.canPlaceTardis(nextLocation) && this.isExitPositionSafe(nextLocation)) {
+                    if (this.canPlaceTardis(nextLocation) && this.isExitPositionSafeOrLandingPad(nextLocation)) {
                         solutionsInRow.add(nextLocation);
                     }
                 }
@@ -518,7 +519,7 @@ public class TardisPilotingManager extends TickableHandler {
             // Check if this position have the space for a TARDIS.
             if (filteredForNonAir.contains(below) && filteredForAir.contains(above)) {
                 // Check if the exit position allows an entity to be teleported without suffocating or falling.
-                if (this.canPlaceTardis(level, airPos) && this.isExitPositionSafe(level, airPos, direction)) {
+                if (this.canPlaceTardis(level, airPos) && this.isExitPositionSafeOrLandingPad(level, airPos, direction)) {
                     var targetDirection = directionOverrides.getOrDefault(airPos, direction);
                     solutionsInRow.add(new TardisNavLocation(airPos, targetDirection, level));
                 }
@@ -632,13 +633,25 @@ public class TardisPilotingManager extends TickableHandler {
         return false;
     }
 
+    private boolean onLandingPad(ServerLevel level, BlockPos pos) {
+        return level.getBlockState(pos.below()).is(TRBlockRegistry.LANDING_PAD.get());
+    }
+
+    private boolean isExitPositionSafeOrLandingPad(ServerLevel level, BlockPos pos, Direction offsetDirection) {
+        return isExitPositionSafe(level, pos, offsetDirection) || onLandingPad(level, pos);
+    }
+
+    private boolean isExitPositionSafeOrLandingPad(TardisNavLocation location) {
+        return this.isExitPositionSafeOrLandingPad(location.getLevel(), location.getPosition(), location.getDirection());
+    }
+
     /**
      * If there is a 2 block vertical space for the exterior to be placed at, and the block below the exterior is solid
      */
     private boolean canPlaceTardis(TardisNavLocation location) {
         ServerLevel targetLevel = location.getLevel();
         BlockPos pos = location.getPosition();
-        boolean isBelowLogicalHeight = pos.getY() < (targetLevel.getMinBuildHeight() + targetLevel.getLogicalHeight());
+        boolean isBelowLogicalHeight = pos.getY() < (targetLevel.getMinBuildHeight() + targetLevel.getLogicalHeight()) || onLandingPad(location.getLevel(), location.getPosition());
         return isBelowLogicalHeight && this.isLegalLandingBlock(targetLevel, pos, LandingBlockType.AIR) && isLegalLandingBlock(targetLevel, pos.above(), LandingBlockType.AIR) && isLegalLandingBlock(targetLevel, pos.below(), LandingBlockType.GROUND);
     }
 

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -502,8 +502,8 @@ public class TardisPilotingManager extends TickableHandler {
         //Out of all the positions which are considered empty spaces (air), check if each position allows for the Tardis exterior to be placed and the area outside the door is safe
         for (BlockPos airPos : filteredForAir) {
 
-            // Ignore any higher scans above the nether roof.
-            if (level.dimension() == Level.NETHER && airPos.getY() > 125) {
+            // Ignore any higher scans above the logical height (e.g. nether roof).
+            if (airPos.getY() >= (level.getMinBuildHeight() + level.getLogicalHeight())) {
                 continue;
             }
 
@@ -638,8 +638,8 @@ public class TardisPilotingManager extends TickableHandler {
     private boolean canPlaceTardis(TardisNavLocation location) {
         ServerLevel targetLevel = location.getLevel();
         BlockPos pos = location.getPosition();
-        boolean isBelowNetherRoof = (targetLevel.dimension() == Level.NETHER && pos.getY() <= 125);
-        return isBelowNetherRoof && this.isLegalLandingBlock(targetLevel, pos, LandingBlockType.AIR) && isLegalLandingBlock(targetLevel, pos.above(), LandingBlockType.AIR) && isLegalLandingBlock(targetLevel, pos.below(), LandingBlockType.GROUND);
+        boolean isBelowLogicalHeight = pos.getY() < (targetLevel.getMinBuildHeight() + targetLevel.getLogicalHeight());
+        return isBelowLogicalHeight && this.isLegalLandingBlock(targetLevel, pos, LandingBlockType.AIR) && isLegalLandingBlock(targetLevel, pos.above(), LandingBlockType.AIR) && isLegalLandingBlock(targetLevel, pos.below(), LandingBlockType.GROUND);
     }
 
     /**


### PR DESCRIPTION
This is technically 2 bugs in one PR, but they both touch the same file so this way there will be fewer merge conflicts to deal with.

The first fix should allow TARDIS Refined to work better with Amplified Nether, although a separate datapack to set the logical height to 256 will be necessary. It will also prevent the TARDIS from landing above the dimension roof in modded dimensions such as The Factory from Realms of Redemption.

The second fix means landing pads can now be used above nether roof and should fix #518.