### PR TITLE
Make the config options for banned dimensions and adventure mode defaults more dynamic.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - New config option to disable teleportation for the Immersive Portals portal, instead teleporting the player directly as if Immersive Portals integration was disabled.
 - New config option to toggle the above setting separately when the door is on a Valkyrien Skies ship.
 - New config option to disable the collision box of the door while open with Immersive Portals integration enabled on Valkyrien Skies ships.
+- Banned Dimensions and Adventure Mode Defaults can now accept namespace, substring and regex entries.
 
 #### Bug Fix
 - Bug fix: TARDIS exterior disappears when moved by other mods.

--- a/common/src/main/java/whocraft/tardis_refined/TRConfig.java
+++ b/common/src/main/java/whocraft/tardis_refined/TRConfig.java
@@ -85,7 +85,7 @@ public class TRConfig {
 
         public Server(ForgeConfigSpec.Builder builder) {
             builder.push("travel");
-            BANNED_DIMENSIONS = builder.translation("config.tardis_refined.banned_dimensions").comment("A list of Dimensions the TARDIS cannot land in.").defineList("banned_dimensions", Lists.newArrayList("example:dimension", "immersive_portals:alternate1", "immersive_portals:alternate2", "immersive_portals:alternate3", "immersive_portals:alternate4", "immersive_portals:alternate5"), String.class::isInstance);
+            BANNED_DIMENSIONS = builder.translation("config.tardis_refined.banned_dimensions").comment("A list of Dimensions the TARDIS cannot land in.").defineList("banned_dimensions", Lists.newArrayList("example:dimension", "[substring]will_match_any_dimansion_containing_this_substring", "[namespace]immersive_portals", "[regex]insert_regex_here"), String.class::isInstance);
             ADVENTURE_MODE_DEFAULTS = builder.translation("config.tardis_refined.adventure_mode_defaults").comment("A list of Dimensions that are automatically sampled").defineList("adventure_mode_defaults", Lists.newArrayList("minecraft:overworld"), String.class::isInstance);
             ADVENTURE_MODE = builder.translation("config.tardis_refined.adventure_mode").comment("Toggles whether players must discover and sample dimensions before they can travel there").define("adventure_mode", false);
             builder.pop();

--- a/common/src/main/java/whocraft/tardis_refined/TRConfig.java
+++ b/common/src/main/java/whocraft/tardis_refined/TRConfig.java
@@ -85,7 +85,7 @@ public class TRConfig {
 
         public Server(ForgeConfigSpec.Builder builder) {
             builder.push("travel");
-            BANNED_DIMENSIONS = builder.translation("config.tardis_refined.banned_dimensions").comment("A list of Dimensions the TARDIS cannot land in.").defineList("banned_dimensions", Lists.newArrayList("example:dimension", "[substring]will_match_any_dimansion_containing_this_substring", "[namespace]immersive_portals", "[regex]insert_regex_here"), String.class::isInstance);
+            BANNED_DIMENSIONS = builder.translation("config.tardis_refined.banned_dimensions").comment("A list of Dimensions the TARDIS cannot land in.").defineList("banned_dimensions", Lists.newArrayList("example:dimension", "[substring]will_match_any_dimension_containing_this_substring", "[namespace]immersive_portals", "[regex]insert_regex_here"), String.class::isInstance);
             ADVENTURE_MODE_DEFAULTS = builder.translation("config.tardis_refined.adventure_mode_defaults").comment("A list of Dimensions that are automatically sampled").defineList("adventure_mode_defaults", Lists.newArrayList("minecraft:overworld"), String.class::isInstance);
             ADVENTURE_MODE = builder.translation("config.tardis_refined.adventure_mode").comment("Toggles whether players must discover and sample dimensions before they can travel there").define("adventure_mode", false);
             builder.pop();

--- a/common/src/main/java/whocraft/tardis_refined/TRConfig.java
+++ b/common/src/main/java/whocraft/tardis_refined/TRConfig.java
@@ -85,7 +85,7 @@ public class TRConfig {
 
         public Server(ForgeConfigSpec.Builder builder) {
             builder.push("travel");
-            BANNED_DIMENSIONS = builder.translation("config.tardis_refined.banned_dimensions").comment("A list of Dimensions the TARDIS cannot land in.").defineList("banned_dimensions", Lists.newArrayList("example:dimension"), String.class::isInstance);
+            BANNED_DIMENSIONS = builder.translation("config.tardis_refined.banned_dimensions").comment("A list of Dimensions the TARDIS cannot land in.").defineList("banned_dimensions", Lists.newArrayList("example:dimension", "immersive_portals:alternate1", "immersive_portals:alternate2", "immersive_portals:alternate3", "immersive_portals:alternate4", "immersive_portals:alternate5"), String.class::isInstance);
             ADVENTURE_MODE_DEFAULTS = builder.translation("config.tardis_refined.adventure_mode_defaults").comment("A list of Dimensions that are automatically sampled").defineList("adventure_mode_defaults", Lists.newArrayList("minecraft:overworld"), String.class::isInstance);
             ADVENTURE_MODE = builder.translation("config.tardis_refined.adventure_mode").comment("Toggles whether players must discover and sample dimensions before they can travel there").define("adventure_mode", false);
             builder.pop();

--- a/common/src/main/java/whocraft/tardis_refined/common/capability/tardis/TardisLevelOperator.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/capability/tardis/TardisLevelOperator.java
@@ -86,7 +86,7 @@ public class TardisLevelOperator {
         this.upgradeHandler = new UpgradeHandler(this);
         this.aestheticHandler = new AestheticHandler(this);
         this.flightDanceManager = new FlightDanceManager(this);
-        this.progressionManager = new ProgressionManager();
+        this.progressionManager = new ProgressionManager(level);
     }
 
     @ExpectPlatform

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/ProgressionManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/ProgressionManager.java
@@ -17,9 +17,13 @@ import java.util.stream.Collectors;
 
 public class ProgressionManager extends BaseHandler {
 
+    private final Level level;
     private ArrayList<ResourceKey<Level>> DISCOVERED_LEVELS = new ArrayList<>();
 
-    public ProgressionManager() {
+    private boolean initialized = false;
+
+    public ProgressionManager(Level level) {
+        this.level = level;
         this.DISCOVERED_LEVELS = new ArrayList<>();
     }
 
@@ -29,9 +33,14 @@ public class ProgressionManager extends BaseHandler {
             return new ArrayList<>(DimensionUtil.getAllowedDimensions(Platform.getServer()));
         }
 
-        for (String defaults : TRConfig.SERVER.ADVENTURE_MODE_DEFAULTS.get()) {
-            ResourceKey<Level> level = ResourceKey.create(Registries.DIMENSION, new ResourceLocation(defaults));
-            addDiscoveredLevel(level);
+        if (!initialized && level.getServer() != null) {
+            var predicate = DimensionUtil.getDimensionPredicate(TRConfig.SERVER.ADVENTURE_MODE_DEFAULTS.get());
+            for (var dim : level.getServer().getAllLevels()) {
+                if (predicate.test(dim.dimension())) {
+                    addDiscoveredLevel(dim.dimension());
+                }
+            }
+            initialized = true;
         }
 
         return DISCOVERED_LEVELS.stream()

--- a/common/src/main/java/whocraft/tardis_refined/common/util/DimensionUtil.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/util/DimensionUtil.java
@@ -9,15 +9,40 @@ import whocraft.tardis_refined.TRConfig;
 import whocraft.tardis_refined.TardisRefined;
 import whocraft.tardis_refined.registry.TRDimensionTypes;
 
+import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 public class DimensionUtil {
 
+    private static final String REGEX_PREFIX = "[regex]";
+    private static final String SUBSTRING_PREFIX = "[substring]";
+    private static final String NAMESPACE_PREFIX = "[namespace]";
+
+    public static Predicate<ResourceKey<Level>> getDimensionPredicate(String configEntry) {
+        if (configEntry.startsWith(REGEX_PREFIX)) {
+            String regex = configEntry.substring(REGEX_PREFIX.length());
+            return dim -> dim.location().toString().matches(regex);
+        }
+        if (configEntry.startsWith(SUBSTRING_PREFIX)) {
+            String substring = configEntry.substring(SUBSTRING_PREFIX.length());
+            return dim -> dim.location().toString().contains(substring);
+        }
+        if (configEntry.startsWith(NAMESPACE_PREFIX)) {
+            String namespace = configEntry.substring(NAMESPACE_PREFIX.length());
+            return dim -> dim.location().getNamespace().equals(namespace);
+        }
+        return dim -> dim.location().toString().equals(configEntry);
+    }
+
+    public static Predicate<ResourceKey<Level>> getDimensionPredicate(List<? extends String> configEntries) {
+        return configEntries.stream().map(DimensionUtil::getDimensionPredicate).reduce(Predicate::or).orElse(dim -> false);
+    }
+
     public static boolean isAllowedDimension(ResourceKey<Level> level) {
         String namespace = level.location().getNamespace();
-        String location = level.location().toString();
-        var bannedDimensions = TRConfig.SERVER.BANNED_DIMENSIONS.get();
-        return !namespace.contains(TardisRefined.MODID) && !bannedDimensions.contains(location);
+        var bannedDimensions = getDimensionPredicate(TRConfig.SERVER.BANNED_DIMENSIONS.get());
+        return !namespace.contains(TardisRefined.MODID) && !bannedDimensions.test(level);
     }
     public static Set<ResourceKey<Level>> getTardisLevels(MinecraftServer server) {
         Set<ResourceKey<Level>> set = Sets.newHashSet();

--- a/common/src/main/java/whocraft/tardis_refined/common/util/DimensionUtil.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/util/DimensionUtil.java
@@ -17,7 +17,7 @@ public class DimensionUtil {
         String namespace = level.location().getNamespace();
         String location = level.location().toString();
         var bannedDimensions = TRConfig.SERVER.BANNED_DIMENSIONS.get();
-        return !namespace.contains("immersive_portals") && !namespace.contains(TardisRefined.MODID) && !bannedDimensions.contains(location);
+        return !namespace.contains(TardisRefined.MODID) && !bannedDimensions.contains(location);
     }
     public static Set<ResourceKey<Level>> getTardisLevels(MinecraftServer server) {
         Set<ResourceKey<Level>> set = Sets.newHashSet();


### PR DESCRIPTION
This allows users to specify regex, substring and namespace matchers, which is useful for mods that have a lot of dimensions or mods that add dimensions dynamically. The syntax is similar to [`allowed_symlinks.txt`](https://minecraft.wiki/w/Java_Edition_1.20_Pre-release_7), i.e. users can prefix the config entry with `[type]` to use a custom matcher, otherwise it falls back to the default string matcher from before.

The removal of dimensions in the `immersive_portals` namespace is no longer hardcoded. They are instead in the banned dimensions by default (although users upgrading from older versions will have to add them manually to hide them). The TARDIS interior dimensions are still removed regardless of the config option.